### PR TITLE
[Fix] 태그 등록 시 keypress, keydown 한글 입력시 생기는 버그 수정

### DIFF
--- a/src/components/new/PublishModalForm.test.tsx
+++ b/src/components/new/PublishModalForm.test.tsx
@@ -1,12 +1,17 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { WriteFields } from '@/models/group';
+
+import WRITE_FIELDS_FIXTURE from '../../../fixtures/writeFields';
+
 import PublishModalForm from './PublishModalForm';
 
 describe('PublishModalForm', () => {
   const handleChangeFields = jest.fn();
 
-  const renderPublishModalForm = () => render((
+  const renderPublishModalForm = (fields: WriteFields) => render((
     <PublishModalForm
+      fields={fields}
       onChangeFields={handleChangeFields}
     />
   ));
@@ -14,7 +19,7 @@ describe('PublishModalForm', () => {
   it('등록하기 폼 항목이 나타나야만 한다', () => {
     const labels = ['분류', '모집인원', '모집 종료 설정', '모집 종료일시'];
 
-    renderPublishModalForm();
+    renderPublishModalForm(WRITE_FIELDS_FIXTURE);
 
     labels.forEach((label) => {
       expect(screen.getByLabelText(label)).not.toBeNull();
@@ -23,17 +28,17 @@ describe('PublishModalForm', () => {
 
   describe('태그를 입력한다', () => {
     it('changeFields 이벤트가 발생해야만 한다', () => {
-      renderPublishModalForm();
+      renderPublishModalForm(WRITE_FIELDS_FIXTURE);
 
       const input = screen.getByPlaceholderText('태그를 입력하세요');
 
       fireEvent.change(input, { target: { value: 'test' } });
 
-      fireEvent.keyDown(input, { key: 'Enter', code: 13, charCode: 13 });
+      fireEvent.keyPress(input, { key: 'Enter', code: 13, charCode: 13 });
 
       expect(handleChangeFields).toBeCalledWith({
         name: 'tags',
-        value: ['javascript', 'scala', 'test'],
+        value: ['test'],
       });
     });
   });

--- a/src/components/new/PublishModalForm.tsx
+++ b/src/components/new/PublishModalForm.tsx
@@ -1,14 +1,15 @@
 import React, { ReactElement } from 'react';
 
-import { WriteFieldsForm } from '@/models/group';
+import { WriteFields, WriteFieldsForm } from '@/models/group';
 
 import TagForm from './TagForm';
 
 interface Props {
+  fields: WriteFields;
   onChangeFields: (form: WriteFieldsForm) => void;
 }
 
-function PublishModalForm({ onChangeFields }: Props): ReactElement {
+function PublishModalForm({ fields, onChangeFields }: Props): ReactElement {
   const handleChangTags = (tags: string[]) => onChangeFields({
     name: 'tags',
     value: tags,
@@ -53,7 +54,7 @@ function PublishModalForm({ onChangeFields }: Props): ReactElement {
         </div>
 
         <TagForm
-          tags={['javascript', 'scala']}
+          tags={fields.tags}
           onChange={handleChangTags}
         />
       </form>

--- a/src/components/new/TagForm.test.tsx
+++ b/src/components/new/TagForm.test.tsx
@@ -25,7 +25,7 @@ describe('TagsForm', () => {
   });
 
   describe('태그를 입력한다', () => {
-    context('태그 인풋창에서 "Enter"나 "," 키를 눌렀을 경우', () => {
+    context('태그 인풋창에서 "Enter" 키를 눌렀을 경우', () => {
       context('인풋창에 값이 존재한 경우', () => {
         const tags = ['JavaScript', 'React'];
 
@@ -37,7 +37,7 @@ describe('TagsForm', () => {
           tags.forEach((tag) => {
             fireEvent.change(input, { target: { value: tag } });
 
-            fireEvent.keyDown(input, { key: 'Enter', code: 13, charCode: 13 });
+            fireEvent.keyPress(input, { key: 'Enter', code: 13, charCode: 13 });
 
             expect(input).toHaveValue('');
           });
@@ -56,7 +56,7 @@ describe('TagsForm', () => {
 
           fireEvent.change(input, { target: { value: '' } });
 
-          fireEvent.keyDown(input, { key: 'Enter', code: 13, charCode: 13 });
+          fireEvent.keyPress(input, { key: 'Enter', code: 13, charCode: 13 });
 
           expect(handleChange).not.toBeCalled();
         });
@@ -73,13 +73,31 @@ describe('TagsForm', () => {
           tags.forEach((tag) => {
             fireEvent.change(input, { target: { value: tag } });
 
-            fireEvent.keyDown(input, { key: 'Enter', code: 13, charCode: 13 });
+            fireEvent.keyPress(input, { key: 'Enter', code: 13, charCode: 13 });
 
             expect(input).toHaveValue('');
 
             expect(handleChange).not.toBeCalled();
           });
         });
+      });
+    });
+
+    context('","키를 눌렀을 경우', () => {
+      const tags = ['JavaScript', 'React'];
+
+      it('chang 이벤트가 호출되어야만 한다', () => {
+        renderTagsForm(['CSS']);
+
+        const input = screen.getByPlaceholderText('태그를 입력하세요');
+
+        tags.forEach((tag) => {
+          fireEvent.change(input, { target: { value: tag } });
+
+          fireEvent.keyDown(input, { key: ',', code: 188, charCode: 188 });
+        });
+
+        expect(handleChange).toBeCalled();
       });
     });
 

--- a/src/components/new/TagForm.tsx
+++ b/src/components/new/TagForm.tsx
@@ -28,18 +28,26 @@ function TagForm({ tags: initialTags, onChange }: Props): ReactElement {
     onChange(newTags);
   }, [tags]);
 
+  const actionKeyEvent = useCallback((e: KeyboardEvent<HTMLInputElement>, keys: string[]) => {
+    if (keys.includes(e.key)) {
+      e.preventDefault();
+      insertTag(value.trim());
+      setValue('');
+    }
+  }, [insertTag, value]);
+
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Backspace' && value === '') {
       setTags(tags.slice(0, tags.length - 1));
       return;
     }
 
-    if ([',', 'Enter'].includes(e.key)) {
-      e.preventDefault();
-      insertTag(value.trim());
-      setValue('');
-    }
-  }, [value, insertTag, tags]);
+    actionKeyEvent(e, [',']);
+  }, [value, actionKeyEvent, tags]);
+
+  const handleKeyPress = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    actionKeyEvent(e, ['Enter']);
+  }, [actionKeyEvent]);
 
   const handleRemove = (nextTags: string[]) => {
     setTags(nextTags);
@@ -64,6 +72,7 @@ function TagForm({ tags: initialTags, onChange }: Props): ReactElement {
         value={value}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onKeyPress={handleKeyPress}
       />
       <div>
         태그를 입력하고 쉼표 또는 엔터를 입력하면 태그가 등록됩니다.

--- a/src/containers/new/PublishModalContainer.test.tsx
+++ b/src/containers/new/PublishModalContainer.test.tsx
@@ -2,6 +2,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import WRITE_FIELDS_FIXTURE from '../../../fixtures/writeFields';
+
 import PublishModalContainer from './PublishModalContainer';
 
 describe('PublishModalContainer', () => {
@@ -11,9 +13,10 @@ describe('PublishModalContainer', () => {
     dispatch.mockClear();
 
     (useDispatch as jest.Mock).mockImplementationOnce(() => dispatch);
-    (useSelector as jest.Mock).mockImplementationOnce((selector) => selector({
+    (useSelector as jest.Mock).mockImplementation((selector) => selector({
       groupReducer: {
         isVisible: given.isVisible,
+        writeFields: given.writeFields,
       },
     }));
   });
@@ -23,6 +26,7 @@ describe('PublishModalContainer', () => {
   ));
 
   context('모달창이 보이는 경우', () => {
+    given('writeFields', () => WRITE_FIELDS_FIXTURE);
     given('isVisible', () => true);
 
     it('등록 모달에 대한 내용이 나타나야만 한다', () => {
@@ -62,12 +66,12 @@ describe('PublishModalContainer', () => {
 
         fireEvent.change(input, { target: { value: 'test' } });
 
-        fireEvent.keyDown(input, { key: 'Enter', code: 13, charCode: 13 });
+        fireEvent.keyPress(input, { key: 'Enter', code: 13, charCode: 13 });
 
         expect(dispatch).toBeCalledWith({
           payload: {
             name: 'tags',
-            value: ['javascript', 'scala', 'test'],
+            value: ['test'],
           },
           type: 'group/changeWriteFields',
         });
@@ -76,6 +80,7 @@ describe('PublishModalContainer', () => {
   });
 
   context('모달창이 보이지 않는 경우', () => {
+    given('writeFields', () => WRITE_FIELDS_FIXTURE);
     given('isVisible', () => false);
 
     it('아무것도 렌더링 되지 말아야 한다', () => {

--- a/src/containers/new/PublishModalContainer.tsx
+++ b/src/containers/new/PublishModalContainer.tsx
@@ -11,6 +11,7 @@ import { getGroup } from '@/utils/utils';
 function PublishModalContainer(): ReactElement {
   const dispatch = useAppDispatch();
   const isVisible = useSelector(getGroup('isVisible'));
+  const fields = useSelector(getGroup('writeFields'));
 
   const onClose = useCallback(() => dispatch(setPublishModalVisible(false)), [dispatch]);
   const onSubmit = useCallback(() => dispatch(requestRegisterNewGroup()), [dispatch]);
@@ -26,6 +27,7 @@ function PublishModalContainer(): ReactElement {
       onSubmit={onSubmit}
     >
       <PublishModalForm
+        fields={fields}
         onChangeFields={onChangeFields}
       />
     </PublishModal>


### PR DESCRIPTION
- keydown은 이벤트가 두 번 발생하여, enter 입력시 keypress 사용
- keydown은 backspace 채크와 , 입력시 태그 등록
- 하지만, 쉼표는 여전히 이벤트 두번 발생.