### PR TITLE
[Improve] 모집 종료 설정(조건)에 따라 종료 일시를 변경하여 입력하게 하라

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -133,6 +133,8 @@ module.exports = {
       labelAttributes: ['label'],
       depth: 3,
     }],
-    'react/require-default-props': 'off',
+    'react/require-default-props': [2, {
+      ignoreFunctionalComponents: true,
+    }],
   },
 };

--- a/src/components/new/NewHeader.test.tsx
+++ b/src/components/new/NewHeader.test.tsx
@@ -5,6 +5,10 @@ import NewHeader from './NewHeader';
 describe('NewHeader', () => {
   const handleSubmit = jest.fn();
 
+  beforeEach(() => {
+    handleSubmit.mockClear();
+  });
+
   const renderNewHeader = () => render((
     <NewHeader
       onSubmit={handleSubmit}

--- a/src/components/new/NewWriteForm.test.tsx
+++ b/src/components/new/NewWriteForm.test.tsx
@@ -1,17 +1,19 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import WRITE_FIELDS_FIXTURE from '../../../fixtures/writeFields';
+
 import NewWriteForm from './NewWriteForm';
 
 describe('NewWriteForm', () => {
-  const initialFields = {
-    title: '',
-    contents: '',
-  };
   const handleChange = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+  });
 
   const renderNewWriteForm = () => render((
     <NewWriteForm
-      fields={initialFields}
+      fields={WRITE_FIELDS_FIXTURE}
       onChange={handleChange}
     />
   ));

--- a/src/components/new/PublishModalForm.test.tsx
+++ b/src/components/new/PublishModalForm.test.tsx
@@ -9,6 +9,10 @@ import PublishModalForm from './PublishModalForm';
 describe('PublishModalForm', () => {
   const handleChangeFields = jest.fn();
 
+  beforeEach(() => {
+    handleChangeFields.mockClear();
+  });
+
   const renderPublishModalForm = (fields: WriteFields) => render((
     <PublishModalForm
       fields={fields}
@@ -37,6 +41,31 @@ describe('PublishModalForm', () => {
       expect(handleChangeFields).toBeCalledWith({
         name: 'category',
         value: 'study',
+      });
+    });
+  });
+
+  describe('모집 종료 설정에 따라 모집 종료일시 상태가 변경된다', () => {
+    context('모집 종료 설정이 "입력한 시간에 자동으로 종료"인 경우', () => {
+      it('모집 종료일시는 "disabled" 속성이 없어야만 한다', () => {
+        renderPublishModalForm(WRITE_FIELDS_FIXTURE);
+
+        expect(screen.getByLabelText('모집 종료일시')).not.toHaveAttribute('disabled');
+      });
+    });
+
+    context('모집 종료 설정이 "미지정"인 경우', () => {
+      it('모집 종료일시는 "disabled" 속성이 있어야하고, changeFields 이벤트가 발생해야만 한다', () => {
+        renderPublishModalForm({
+          ...WRITE_FIELDS_FIXTURE,
+          recruitmentEndSetting: 'manual',
+        });
+
+        expect(screen.getByLabelText('모집 종료일시')).toHaveAttribute('disabled');
+        expect(handleChangeFields).toBeCalledWith({
+          name: 'recruitmentEndDate',
+          value: '',
+        });
       });
     });
   });

--- a/src/components/new/PublishModalForm.tsx
+++ b/src/components/new/PublishModalForm.tsx
@@ -1,4 +1,6 @@
-import React, { ChangeEvent, ReactElement } from 'react';
+import React, {
+  ChangeEvent, ReactElement, useEffect, useState,
+} from 'react';
 
 import { WriteFields, WriteFieldsForm } from '@/models/group';
 import { stringToExcludeNull } from '@/utils/utils';
@@ -13,6 +15,7 @@ interface Props {
 }
 
 function PublishModalForm({ fields, onChangeFields }: Props): ReactElement {
+  const [isEndDateDisabled, setEndDateDisabled] = useState<boolean>(false);
   const {
     recruitmentNumber, category, recruitmentEndSetting, recruitmentEndDate, tags: initialTags,
   } = fields;
@@ -25,8 +28,21 @@ function PublishModalForm({ fields, onChangeFields }: Props): ReactElement {
   const handleChangeFields = (e: ChangeEvent<HTMLInputElement| HTMLSelectElement>) => {
     const { value, name } = e.target;
 
-    onChangeFields({ value, name });
+    onChangeFields({ name, value });
   };
+
+  useEffect(() => {
+    if (recruitmentEndSetting === 'manual') {
+      setEndDateDisabled(true);
+      onChangeFields({
+        name: 'recruitmentEndDate',
+        value: '',
+      });
+      return;
+    }
+
+    setEndDateDisabled(false);
+  }, [recruitmentEndSetting]);
 
   return (
     <div>
@@ -87,6 +103,7 @@ function PublishModalForm({ fields, onChangeFields }: Props): ReactElement {
             type="datetime-local"
             onChange={handleChangeFields}
             value={stringToExcludeNull(recruitmentEndDate)}
+            disabled={isEndDateDisabled}
           />
         </label>
       </div>


### PR DESCRIPTION
- 모집 종료 설정이 "입력한 시간에 자동으로 종료" 시 모집 종료 일시 입력
- 모집 종료 설정이 자동으로 입력이 아닐 때 모집 종료 일시 disabled