### PR TITLE
[Feature] 스터디(프로젝트) 글 등록 후 해당 detail 페이지로 이동하게 하라

### DIFF
--- a/fixtures/group.ts
+++ b/fixtures/group.ts
@@ -1,0 +1,16 @@
+import { Group } from '@/models/group';
+
+const group: Group = {
+  groupId: '1',
+  writer: 'test',
+  title: 'title',
+  contents: 'contents',
+  tags: [],
+  category: 'frontEnd',
+  recruitmentEndDate: '',
+  recruitmentEndSetting: 'manual',
+  recruitmentNumber: 1,
+  createAt: '2021-10-11',
+};
+
+export default group;

--- a/fixtures/initialStore.ts
+++ b/fixtures/initialStore.ts
@@ -7,6 +7,7 @@ const initialStore = {
       isVisible: false,
     },
     groupReducer: {
+      group: null,
       groupError: null,
       groupId: null,
       writeFields: {

--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,7 @@
 module.exports = {
   reactStrictMode: true,
   pageExtensions: ['page.tsx', 'api.ts'],
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };

--- a/src/containers/detail/DetailHeaderContainer.test.tsx
+++ b/src/containers/detail/DetailHeaderContainer.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import DetailHeaderContainer from './DetailHeaderContainer';
+
+describe('DetailHeaderContainer', () => {
+  const renderDetailHeaderContainer = () => render((
+    <DetailHeaderContainer />
+  ));
+
+  it('DetailHeaderContainer에 대한 내용이 나타나야만 한다', () => {
+    const { container } = renderDetailHeaderContainer();
+
+    expect(container).toHaveTextContent('detail 페이지');
+  });
+});

--- a/src/containers/detail/DetailHeaderContainer.tsx
+++ b/src/containers/detail/DetailHeaderContainer.tsx
@@ -1,0 +1,11 @@
+import React, { ReactElement } from 'react';
+
+function DetailHeaderContainer(): ReactElement {
+  return (
+    <div>
+      detail 페이지
+    </div>
+  );
+}
+
+export default DetailHeaderContainer;

--- a/src/containers/new/NewHeaderContainer.test.tsx
+++ b/src/containers/new/NewHeaderContainer.test.tsx
@@ -64,7 +64,7 @@ describe('NewHeaderContainer', () => {
     it('"router.replace"가 "/"와 같이 호출되어야만 한다', async () => {
       renderNewHeaderContainer();
 
-      expect(mockReplace).toBeCalledWith('/');
+      expect(mockReplace).toBeCalledWith('/detail/1');
     });
   });
 });

--- a/src/containers/new/NewHeaderContainer.tsx
+++ b/src/containers/new/NewHeaderContainer.tsx
@@ -17,7 +17,7 @@ function NewHeaderContainer(): ReactElement {
 
   useEffect(() => {
     if (groupId) {
-      router.replace('/');
+      router.replace(`/detail/${groupId}`);
     }
   }, [groupId]);
 

--- a/src/models/group.ts
+++ b/src/models/group.ts
@@ -11,6 +11,19 @@ export interface WriteFields {
   recruitmentEndDate: string | null;
 }
 
+export interface Group {
+  groupId: string;
+  title: string;
+  contents: string;
+  tags: string[];
+  category: Category | string;
+  recruitmentNumber: number;
+  recruitmentEndSetting: RecruitmentEndSetting;
+  recruitmentEndDate: string | null;
+  writer: string;
+  createAt: string;
+}
+
 export interface WriteFieldsForm {
   name: string;
   value: string | string[];

--- a/src/pages/detail/[id].page.tsx
+++ b/src/pages/detail/[id].page.tsx
@@ -1,0 +1,47 @@
+import { ParsedUrlQuery } from 'querystring';
+
+import React, { ReactElement } from 'react';
+
+import { GetServerSideProps } from 'next';
+
+import DetailHeaderContainer from '@/containers/detail/DetailHeaderContainer';
+import { setGroup } from '@/reducers/groupSlice';
+import wrapper from '@/reducers/store';
+import { getGroupDetail } from '@/services/api/group';
+
+interface Params extends ParsedUrlQuery {
+  id: string;
+}
+
+export const getServerSideProps: GetServerSideProps = wrapper
+  .getServerSideProps((store) => async (context) => {
+    const { id } = context.params! as Params;
+
+    if (!id) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const group = await getGroupDetail(id);
+
+    if (!group) {
+      return {
+        notFound: true,
+      };
+    }
+
+    store.dispatch(setGroup(group));
+
+    return {
+      props: {},
+    };
+  });
+
+function DetailPage(): ReactElement {
+  return (
+    <DetailHeaderContainer />
+  );
+}
+
+export default DetailPage;

--- a/src/pages/detail/[id].test.tsx
+++ b/src/pages/detail/[id].test.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { ParsedUrlQuery } from 'querystring';
+
+import { render } from '@testing-library/react';
+import { GetServerSidePropsContext } from 'next';
+
+import { getGroupDetail } from '@/services/api/group';
+
+import GROUP_FIXTURE from '../../../fixtures/group';
+
+import DetailPage, { getServerSideProps } from './[id].page';
+
+jest.mock('@/services/api/group');
+
+describe('DetailPage', () => {
+  const renderDetailPage = () => render((
+    <DetailPage />
+  ));
+
+  it('detail 페이지에 대한 내용이 나타나야만 한다', () => {
+    const { container } = renderDetailPage();
+
+    expect(container).toHaveTextContent('detail 페이지');
+  });
+});
+
+describe('getServerSideProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(window.console, 'log').mockImplementation(() => null);
+  });
+
+  context('params가 존재하지 않는 경우', () => {
+    const mockContext = {
+      params: { id: '' } as ParsedUrlQuery,
+    };
+
+    it('notFound가 "true"를 반환해야만 한다', async () => {
+      const response: any = await getServerSideProps(mockContext as GetServerSidePropsContext);
+
+      expect(response.notFound).toBeTruthy();
+    });
+  });
+
+  context('해당 id를 가진 detail 페이지 정보가 없을 경우', () => {
+    const mockContext = {
+      params: { id: 'id' } as ParsedUrlQuery,
+    };
+
+    beforeEach(() => {
+      (getGroupDetail as jest.Mock).mockReturnValueOnce('');
+    });
+
+    it('notFound가 "true"를 반환해야만 한다', async () => {
+      const response: any = await getServerSideProps(mockContext as GetServerSidePropsContext);
+
+      expect(getGroupDetail).toBeCalledWith('id');
+      expect(response.notFound).toBeTruthy();
+    });
+  });
+
+  context('해당 id를 가진 detail 페이지 정보가 존재하는 경우', () => {
+    const mockContext = {
+      params: { id: 'id' } as ParsedUrlQuery,
+    };
+
+    beforeEach(() => {
+      (getGroupDetail as jest.Mock).mockReturnValueOnce(GROUP_FIXTURE);
+    });
+
+    it('그룹 정보가 반환되어야만 한다', async () => {
+      const response: any = await getServerSideProps(mockContext as GetServerSidePropsContext);
+
+      expect(getGroupDetail).toBeCalledWith('id');
+      expect(response.props.initialState.groupReducer.group).toEqual(GROUP_FIXTURE);
+    });
+  });
+});

--- a/src/reducers/groupSlice.test.ts
+++ b/src/reducers/groupSlice.test.ts
@@ -2,15 +2,18 @@
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import { postNewGroup } from '@/services/api/group';
+import { getGroupDetail, postNewGroup } from '@/services/api/group';
 
+import GROUP_FIXTURE from '../../fixtures/group';
 import WRITE_FIELDS_FIXTURE from '../../fixtures/writeFields';
 
 import reducer, {
   changeWriteFields,
   clearWriteFields,
   GroupStore,
+  loadGroupDetail,
   requestRegisterNewGroup,
+  setGroup,
   setGroupError,
   setGroupId,
   setPublishModalVisible,
@@ -24,6 +27,7 @@ jest.mock('@/services/api/group');
 
 describe('groupReducer', () => {
   const initialState: GroupStore = {
+    group: null,
     groupId: null,
     groupError: null,
     writeFields: WRITE_FIELDS_FIXTURE,
@@ -35,6 +39,14 @@ describe('groupReducer', () => {
       const state = reducer(undefined, { type: 'action' });
 
       expect(state).toEqual(initialState);
+    });
+  });
+
+  describe('setGroup', () => {
+    it('group 필드가 변경되어야 한다', () => {
+      const { group } = reducer(initialState, setGroup(GROUP_FIXTURE));
+
+      expect(group).toBe(GROUP_FIXTURE);
     });
   });
 
@@ -140,6 +152,52 @@ describe('groupReducer async actions', () => {
       it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
         try {
           await store.dispatch(requestRegisterNewGroup('userUid'));
+        } catch (error) {
+          // ignore errors
+        } finally {
+          const actions = store.getActions();
+
+          expect(actions[0]).toEqual({
+            payload: 'error',
+            type: 'group/setGroupError',
+          });
+        }
+      });
+    });
+  });
+
+  describe('loadGroupDetail', () => {
+    beforeEach(() => {
+      store = mockStore({
+        groupReducer: {
+          group: GROUP_FIXTURE,
+        },
+      });
+    });
+
+    context('에러가 발생하지 않는 경우', () => {
+      (getGroupDetail as jest.Mock).mockReturnValueOnce(GROUP_FIXTURE);
+
+      it('dispatch 액션이 "group/setGroup"인 타입과 payload는 group 정보이어야 한다', async () => {
+        await store.dispatch(loadGroupDetail('id'));
+
+        const actions = store.getActions();
+
+        expect(actions[0]).toEqual({
+          payload: GROUP_FIXTURE,
+          type: 'group/setGroup',
+        });
+      });
+    });
+
+    context('에러가 발생하는 경우', () => {
+      (getGroupDetail as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('error');
+      });
+
+      it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
+        try {
+          await store.dispatch(loadGroupDetail('id'));
         } catch (error) {
           // ignore errors
         } finally {

--- a/src/reducers/groupSlice.ts
+++ b/src/reducers/groupSlice.ts
@@ -1,12 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { postNewGroup } from '@/services/api/group';
+import { getGroupDetail, postNewGroup } from '@/services/api/group';
 
-import { WriteFields, WriteFieldsForm } from '../models/group';
+import { Group, WriteFields, WriteFieldsForm } from '../models/group';
 
 import type { AppThunk } from './store';
 
 export interface GroupStore {
+  group: Group | null;
   groupError: string | null;
   writeFields: WriteFields;
   groupId: string | null;
@@ -26,6 +27,7 @@ const initialFieldsState: WriteFields = {
 const { actions, reducer } = createSlice({
   name: 'group',
   initialState: {
+    group: null,
     groupId: null,
     groupError: null,
     writeFields: initialFieldsState,
@@ -45,6 +47,12 @@ const { actions, reducer } = createSlice({
       return {
         ...state,
         writeFields: initialFieldsState,
+      };
+    },
+    setGroup(state, { payload: group }: PayloadAction<Group | null>):GroupStore {
+      return {
+        ...state,
+        group,
       };
     },
     setGroupId(state, { payload: id }: PayloadAction<string>):GroupStore {
@@ -69,7 +77,7 @@ const { actions, reducer } = createSlice({
 });
 
 export const {
-  changeWriteFields, clearWriteFields, setGroupError, setGroupId, setPublishModalVisible,
+  changeWriteFields, clearWriteFields, setGroupError, setGroupId, setPublishModalVisible, setGroup,
 } = actions;
 
 export const requestRegisterNewGroup = (
@@ -82,6 +90,18 @@ export const requestRegisterNewGroup = (
 
     dispatch(setGroupId(groupId));
     dispatch(setPublishModalVisible(false));
+  } catch (error) {
+    const { message } = error as Error;
+
+    dispatch(setGroupError(message));
+  }
+};
+
+export const loadGroupDetail = (id: string): AppThunk => async (dispatch) => {
+  try {
+    const response = await getGroupDetail(id);
+
+    dispatch(setGroup(response));
   } catch (error) {
     const { message } = error as Error;
 

--- a/src/reducers/rootReducer.test.ts
+++ b/src/reducers/rootReducer.test.ts
@@ -25,6 +25,7 @@ describe('rootReducer', () => {
       isVisible: false,
     },
     groupReducer: {
+      group: null,
       groupId: null,
       groupError: null,
       writeFields: fieldsInitialState,

--- a/src/services/api/__mocks__/group.ts
+++ b/src/services/api/__mocks__/group.ts
@@ -1,4 +1,3 @@
 export const postNewGroup = jest.fn();
 
-// TODO - 추후 삭제
-export const temp = [];
+export const getGroupDetail = jest.fn();

--- a/src/services/api/group.test.ts
+++ b/src/services/api/group.test.ts
@@ -1,8 +1,9 @@
 import { WriteFields } from '@/models/group';
+import { getGroupDetail, postNewGroup } from '@/services/api/group';
 
 import db, { fireStore } from '../firebase';
 
-import { postNewGroup } from './group';
+jest.mock('@/utils/utils');
 
 describe('group API', () => {
   beforeEach(() => {
@@ -43,6 +44,50 @@ describe('group API', () => {
         createAt,
       });
       expect(id).toBe('1');
+    });
+  });
+
+  describe('getGroupDetail', () => {
+    const mockResponse = {
+      title: 'title',
+      content: 'content',
+    };
+
+    context('exists가 true인 경우', () => {
+      beforeEach(() => {
+        (jest.spyOn(db, 'collection') as jest.Mock).mockImplementationOnce(() => ({
+          doc: jest.fn().mockImplementationOnce(() => ({
+            get: jest.fn().mockReturnValue({
+              exists: true,
+              data: jest.fn().mockReturnValueOnce(mockResponse),
+            }),
+          })),
+        }));
+      });
+
+      it('해당 detail 글 정보가 나타나야만 한다', async () => {
+        const response = await getGroupDetail('id');
+
+        expect(response).toEqual(mockResponse);
+      });
+    });
+
+    context('exists가 false인 경우', () => {
+      beforeEach(() => {
+        (jest.spyOn(db, 'collection') as jest.Mock).mockImplementationOnce(() => ({
+          doc: jest.fn().mockImplementationOnce(() => ({
+            get: jest.fn().mockReturnValue({
+              exists: false,
+            }),
+          })),
+        }));
+      });
+
+      it('null을 반환해야만 한다', async () => {
+        const response = await getGroupDetail('id');
+
+        expect(response).toBeNull();
+      });
     });
   });
 });

--- a/src/services/api/group.ts
+++ b/src/services/api/group.ts
@@ -1,4 +1,5 @@
-import { WriteFields } from '@/models/group';
+import { Group, WriteFields } from '@/models/group';
+import { timestampToString } from '@/utils/utils';
 
 import { collection, fireStore } from '../firebase';
 
@@ -13,5 +14,20 @@ export const postNewGroup = async (writerUid: string, fields: WriteFields) => {
   return id;
 };
 
-// TODO - 추후 삭제
-export const temp = [];
+export const getGroupDetail = async (id: string) => {
+  const response = await collection('groups')
+    .doc(id)
+    .get();
+
+  if (!response.exists) {
+    return null;
+  }
+
+  const group = response.data() as any;
+
+  return {
+    groupId: response.id,
+    ...group,
+    createAt: timestampToString(group.createAt),
+  } as Group;
+};

--- a/src/utils/__mocks__/utils.ts
+++ b/src/utils/__mocks__/utils.ts
@@ -1,0 +1,3 @@
+export const timestampToString = jest.fn((date) => date);
+
+export const isProdLevel = jest.fn();

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -3,7 +3,7 @@ import { RootReducerState } from '@/reducers/rootReducer';
 import WRITE_FIELDS_FIXTURE from '../../fixtures/writeFields';
 
 import {
-  getAuth, getGroup, isProdLevel, stringToExcludeNull,
+  getAuth, getGroup, isProdLevel, stringToExcludeNull, timestampToString,
 } from './utils';
 
 describe('isProdLevel', () => {
@@ -97,5 +97,19 @@ describe('stringToExcludeNull', () => {
 
       expect(result).toBe('');
     });
+  });
+});
+
+describe('timestampToString', () => {
+  const timestamp = {
+    toDate: jest.fn().mockImplementationOnce(() => ({
+      toString: jest.fn().mockReturnValueOnce('2021-11-11'),
+    })),
+  };
+
+  it('날짜 형식으로 변경되어야만 한다', () => {
+    const result = timestampToString(timestamp);
+
+    expect(result).toBe('2021-11-11');
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -23,3 +23,5 @@ export const stringToExcludeNull = (value?: string | null): string => {
 
   return value;
 };
+
+export const timestampToString = (timestamp: any) => timestamp.toDate().toString();


### PR DESCRIPTION
- detail 페이지 구현
- serverside로 params.id 값으로 정보 조회.
- 조회 후 존재하면 redux store에 담김
- 존재하지 않으면 404 