### PR TITLE
[Fix] Production 환경에서 firestore에 접근하지 못하는 오류를 수정하라

### DIFF
--- a/src/services/firebase/firebaseConfig.ts
+++ b/src/services/firebase/firebaseConfig.ts
@@ -1,13 +1,13 @@
 import { isProdLevel } from '@/utils/utils';
 
 export const prodConfig = {
-  apiKey: process.env.FIREBASE_API_KEY,
-  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.FIREBASE_PROJECT_ID,
-  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.FIREBASE_APP_ID,
-  measurementId: process.env.FIREBASE_MEASUREMENT_ID,
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 export const devConfig = {


### PR DESCRIPTION
- next.js에서 브라우저 환경에서 environment에 접근하려면, `NEXT_PUBLIC` 접두어가 붙어야한다.
- https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser