### PR TITLE
[Imporve] 팀 모집하기 등록 모달창에서의 등록 플로우 수정

### DIFF
--- a/fixtures/group.ts
+++ b/fixtures/group.ts
@@ -9,7 +9,6 @@ const group: Group = {
   category: 'frontEnd',
   recruitmentEndDate: '',
   recruitmentEndSetting: 'manual',
-  recruitmentNumber: 1,
   createAt: '2021-10-11',
 };
 

--- a/fixtures/initialStore.ts
+++ b/fixtures/initialStore.ts
@@ -17,7 +17,6 @@ const initialStore = {
         category: '',
         recruitmentEndDate: '',
         recruitmentEndSetting: 'automatic',
-        recruitmentNumber: 1,
       },
       isVisible: false,
     },

--- a/fixtures/writeFields.ts
+++ b/fixtures/writeFields.ts
@@ -7,7 +7,6 @@ const writeFields: WriteFields = {
   category: '',
   recruitmentEndDate: '',
   recruitmentEndSetting: 'automatic',
-  recruitmentNumber: 1,
 };
 
 export default writeFields;

--- a/src/components/new/NewHeader.test.tsx
+++ b/src/components/new/NewHeader.test.tsx
@@ -11,6 +11,7 @@ describe('NewHeader', () => {
 
   const renderNewHeader = () => render((
     <NewHeader
+      title={given.title}
       onSubmit={handleSubmit}
     />
   ));
@@ -23,12 +24,26 @@ describe('NewHeader', () => {
   });
 
   describe('"등록하기" 버튼을 클릭한다', () => {
-    it('클릭 이벤트가 호출되어야만 한다', () => {
-      renderNewHeader();
+    context('제목이 존재하는 경우', () => {
+      given('title', () => 'title');
 
-      fireEvent.click(screen.getByText('등록하기'));
+      it('클릭 이벤트가 호출되어야만 한다', () => {
+        renderNewHeader();
 
-      expect(handleSubmit).toBeCalledTimes(1);
+        fireEvent.click(screen.getByText('등록하기'));
+
+        expect(handleSubmit).toBeCalledTimes(1);
+      });
+    });
+
+    context('제목이 존재하지 않는 경우', () => {
+      given('title', () => '');
+
+      it('"등록하기" 버튼은 disable되어야만 한다', () => {
+        renderNewHeader();
+
+        expect(screen.getByText('등록하기')).toHaveAttribute('disabled');
+      });
     });
   });
 });

--- a/src/components/new/NewHeader.tsx
+++ b/src/components/new/NewHeader.tsx
@@ -4,16 +4,17 @@ import Link from 'next/link';
 
 interface Props {
   onSubmit: () => void;
+  title: string;
 }
 
-function NewHeader({ onSubmit }: Props): ReactElement {
+function NewHeader({ title, onSubmit }: Props): ReactElement {
   return (
     <div>
       <Link href="/" passHref>
         <a>{'< 팀 모집하기'}</a>
       </Link>
 
-      <button type="button" onClick={onSubmit}>
+      <button type="button" onClick={onSubmit} disabled={!title}>
         등록하기
       </button>
     </div>

--- a/src/components/new/PublishModal.test.tsx
+++ b/src/components/new/PublishModal.test.tsx
@@ -11,8 +11,9 @@ describe('PublishModal', () => {
     jest.clearAllMocks();
   });
 
-  const renderPublishModal = () => render((
+  const renderPublishModal = (title = 'title') => render((
     <PublishModal
+      title={title}
       isVisible={given.isVisible}
       onClose={handleClose}
       onSubmit={handleSubmit}
@@ -25,9 +26,11 @@ describe('PublishModal', () => {
     given('isVisible', () => true);
 
     it('모달 타이틀이 나타나야만 한다', () => {
-      const { container } = renderPublishModal();
+      const title = '제목입니다';
 
-      expect(container).toHaveTextContent('제목 없음 등록');
+      const { container } = renderPublishModal(title);
+
+      expect(container).toHaveTextContent(`${title} 등록`);
     });
 
     describe('닫기 버튼을 누른다', () => {

--- a/src/components/new/PublishModal.tsx
+++ b/src/components/new/PublishModal.tsx
@@ -7,13 +7,14 @@ import transitions from '@/styles/transitions';
 import zIndexes from '@/styles/zIndexes';
 
 interface Props {
+  title: string;
   isVisible: boolean;
   onClose: () => void;
   onSubmit: () => void;
 }
 
 function PublishModal({
-  isVisible, onClose, onSubmit, children,
+  title, isVisible, onClose, onSubmit, children,
 }: PropsWithChildren<Props>): ReactElement | null {
   if (!isVisible) {
     return null;
@@ -23,7 +24,7 @@ function PublishModal({
     <PublishModalWrapper>
       <PublishModalBox isVisible={isVisible}>
         <div>
-          <h4>제목 없음 등록</h4>
+          <h4>{`${title} 등록`}</h4>
           <button type="button" onClick={onClose}>X</button>
         </div>
         {children}

--- a/src/components/new/PublishModalForm.test.tsx
+++ b/src/components/new/PublishModalForm.test.tsx
@@ -21,7 +21,7 @@ describe('PublishModalForm', () => {
   ));
 
   it('등록하기 폼 항목이 나타나야만 한다', () => {
-    const labels = ['분류', '모집인원', '모집 종료 설정', '모집 종료일시'];
+    const labels = ['분류', '모집 종료 설정', '모집 종료일시'];
 
     renderPublishModalForm(WRITE_FIELDS_FIXTURE);
 
@@ -54,7 +54,7 @@ describe('PublishModalForm', () => {
       });
     });
 
-    context('모집 종료 설정이 "미지정"인 경우', () => {
+    context('모집 종료 설정이 "수동으로 종료"인 경우', () => {
       it('모집 종료일시는 "disabled" 속성이 있어야하고, changeFields 이벤트가 발생해야만 한다', () => {
         renderPublishModalForm({
           ...WRITE_FIELDS_FIXTURE,

--- a/src/components/new/PublishModalForm.tsx
+++ b/src/components/new/PublishModalForm.tsx
@@ -17,7 +17,7 @@ interface Props {
 function PublishModalForm({ fields, onChangeFields }: Props): ReactElement {
   const [isEndDateDisabled, setEndDateDisabled] = useState<boolean>(false);
   const {
-    recruitmentNumber, category, recruitmentEndSetting, recruitmentEndDate, tags: initialTags,
+    category, recruitmentEndSetting, recruitmentEndDate, tags: initialTags,
   } = fields;
 
   const handleChangeTags = (tags: string[]) => onChangeFields({
@@ -64,21 +64,6 @@ function PublishModalForm({ fields, onChangeFields }: Props): ReactElement {
       </div>
 
       <div>
-        <label htmlFor="recruitmentNumber">
-          모집인원
-          <input
-            id="recruitmentNumber"
-            name="recruitmentNumber"
-            type="number"
-            inputMode="numeric"
-            pattern="[0-9]*"
-            value={recruitmentNumber}
-            onChange={handleChangeFields}
-          />
-        </label>
-      </div>
-
-      <div>
         <label htmlFor="recruitmentEndSetting">
           모집 종료 설정
           <Select
@@ -88,7 +73,7 @@ function PublishModalForm({ fields, onChangeFields }: Props): ReactElement {
             onChange={handleChangeFields}
             options={{
               automatic: '입력한 시간에 자동으로 종료',
-              manual: '미지정',
+              manual: '수동으로 종료',
             }}
           />
         </label>

--- a/src/containers/new/NewHeaderContainer.test.tsx
+++ b/src/containers/new/NewHeaderContainer.test.tsx
@@ -17,10 +17,11 @@ describe('NewHeaderContainer', () => {
     dispatch.mockClear();
     mockReplace.mockClear();
 
-    (useDispatch as jest.Mock).mockImplementationOnce(() => dispatch);
-    (useSelector as jest.Mock).mockImplementationOnce((selector) => selector({
+    (useDispatch as jest.Mock).mockImplementation(() => dispatch);
+    (useSelector as jest.Mock).mockImplementation((selector) => selector({
       groupReducer: {
         groupId: given.groupId,
+        writeFields: given.writeFields,
       },
     }));
   });
@@ -29,24 +30,40 @@ describe('NewHeaderContainer', () => {
     <NewHeaderContainer />
   ));
 
-  it('헤더 정보가 나타나야만 한다', () => {
-    const { container } = renderNewHeaderContainer();
-
-    expect(container).toHaveTextContent('등록하기');
-  });
-
   context('글을 작성하지 않은 경우', () => {
     given('groupId', () => null);
 
-    describe('"등록하기" 버튼을 클릭한다', () => {
-      it('클릭 이베트가 발생해야만 한다', () => {
-        renderNewHeaderContainer();
+    context('제목이 작성되지 않은 경우', () => {
+      given('writeFields', () => ({
+        title: '',
+      }));
 
-        fireEvent.click(screen.getByText('등록하기'));
+      describe('"등록하기" 버튼을 클릭한다', () => {
+        it('클릭 이베트가 발생해야만 한다', () => {
+          renderNewHeaderContainer();
 
-        expect(dispatch).toBeCalledWith({
-          type: 'group/setPublishModalVisible',
-          payload: true,
+          fireEvent.click(screen.getByText('등록하기'));
+
+          expect(dispatch).not.toBeCalled();
+        });
+      });
+    });
+
+    context('제목이 작성된 경우', () => {
+      given('writeFields', () => ({
+        title: 'title',
+      }));
+
+      describe('"등록하기" 버튼을 클릭한다', () => {
+        it('클릭 이베트가 발생해야만 한다', () => {
+          renderNewHeaderContainer();
+
+          fireEvent.click(screen.getByText('등록하기'));
+
+          expect(dispatch).toBeCalledWith({
+            type: 'group/setPublishModalVisible',
+            payload: true,
+          });
         });
       });
     });
@@ -54,6 +71,9 @@ describe('NewHeaderContainer', () => {
 
   context('이미 글을 작성한 경우', () => {
     given('groupId', () => '1');
+    given('writeFields', () => ({
+      title: 'title',
+    }));
 
     beforeEach(() => {
       (useRouter as jest.Mock).mockImplementationOnce(() => ({

--- a/src/containers/new/NewHeaderContainer.tsx
+++ b/src/containers/new/NewHeaderContainer.tsx
@@ -12,6 +12,7 @@ function NewHeaderContainer(): ReactElement {
   const router = useRouter();
   const dispatch = useAppDispatch();
   const groupId = useSelector(getGroup('groupId'));
+  const { title } = useSelector(getGroup('writeFields'));
 
   const onSubmit = useCallback(() => dispatch(setPublishModalVisible(true)), [dispatch]);
 
@@ -23,6 +24,7 @@ function NewHeaderContainer(): ReactElement {
 
   return (
     <NewHeader
+      title={title}
       onSubmit={onSubmit}
     />
   );

--- a/src/containers/new/PublishModalContainer.test.tsx
+++ b/src/containers/new/PublishModalContainer.test.tsx
@@ -32,13 +32,18 @@ describe('PublishModalContainer', () => {
   ));
 
   context('모달창이 보이는 경우', () => {
-    given('writeFields', () => WRITE_FIELDS_FIXTURE);
+    const title = '제목입니다.';
+
+    given('writeFields', () => ({
+      ...WRITE_FIELDS_FIXTURE,
+      title,
+    }));
     given('isVisible', () => true);
 
     it('등록 모달에 대한 내용이 나타나야만 한다', () => {
       const { container } = renderPublishModalContainer();
 
-      expect(container).toHaveTextContent('제목 없음 등록');
+      expect(container).toHaveTextContent(`${title} 등록`);
     });
 
     describe('닫기 버튼을 클릭한다', () => {

--- a/src/containers/new/PublishModalContainer.tsx
+++ b/src/containers/new/PublishModalContainer.tsx
@@ -27,6 +27,7 @@ function PublishModalContainer(): ReactElement {
 
   return (
     <PublishModal
+      title={fields.title}
       isVisible={isVisible}
       onClose={onClose}
       onSubmit={onSubmit}

--- a/src/models/group.ts
+++ b/src/models/group.ts
@@ -6,7 +6,6 @@ export interface WriteFields {
   contents: string;
   tags: string[];
   category: Category | string;
-  recruitmentNumber: number | string;
   recruitmentEndSetting: RecruitmentEndSetting;
   recruitmentEndDate: string | null;
 }
@@ -17,7 +16,6 @@ export interface Group {
   contents: string;
   tags: string[];
   category: Category | string;
-  recruitmentNumber: number;
   recruitmentEndSetting: RecruitmentEndSetting;
   recruitmentEndDate: string | null;
   writer: string;

--- a/src/pages/new.test.tsx
+++ b/src/pages/new.test.tsx
@@ -1,3 +1,5 @@
+import { useSelector } from 'react-redux';
+
 import { render } from '@testing-library/react';
 import { useSession } from 'next-auth/client';
 
@@ -9,6 +11,14 @@ describe('New page', () => {
   ));
 
   beforeEach(() => {
+    (useSelector as jest.Mock).mockImplementation((selector) => selector({
+      groupReducer: {
+        groupId: '',
+        writeFields: {
+          title: '',
+        },
+      },
+    }));
     (useSession as jest.Mock).mockImplementation(() => ([given.session, given.loading]));
   });
 

--- a/src/reducers/groupSlice.ts
+++ b/src/reducers/groupSlice.ts
@@ -21,7 +21,6 @@ const initialFieldsState: WriteFields = {
   category: '',
   recruitmentEndDate: '',
   recruitmentEndSetting: 'automatic',
-  recruitmentNumber: 1,
 };
 
 const { actions, reducer } = createSlice({

--- a/src/reducers/rootReducer.test.ts
+++ b/src/reducers/rootReducer.test.ts
@@ -12,7 +12,6 @@ describe('rootReducer', () => {
     contents: '',
     tags: [],
     category: '',
-    recruitmentNumber: 1,
     recruitmentEndSetting: 'manual',
     recruitmentEndDate: '',
   };

--- a/src/services/api/group.test.ts
+++ b/src/services/api/group.test.ts
@@ -22,7 +22,6 @@ describe('group API', () => {
       category: '',
       recruitmentEndDate: '',
       recruitmentEndSetting: 'automatic',
-      recruitmentNumber: 1,
     };
 
     beforeEach(() => {

--- a/src/services/api/group.ts
+++ b/src/services/api/group.ts
@@ -6,7 +6,6 @@ import { collection, fireStore } from '../firebase';
 export const postNewGroup = async (writerUid: string, fields: WriteFields) => {
   const { id } = await collection('groups').add({
     ...fields,
-    recruitmentNumber: Number(fields.recruitmentNumber),
     writerUid,
     createAt: fireStore.FieldValue.serverTimestamp(),
   });


### PR DESCRIPTION
- 팀 등록하기 모달창에서 모집 인원수 등록 폼을 제거
- 팀 등록하기 모달에 입력한 제목이 타이틀로 보인다.
- 제목을 미 입력시 등록하기 버튼 disable