### PR TITLE
[Refactor] firestore group collection 항목 변경으로 인해 코드 리팩터링하라

### DIFF
--- a/fixtures/group.ts
+++ b/fixtures/group.ts
@@ -1,8 +1,10 @@
 import { Group } from '@/models/group';
 
+import PROFILE_FIXTURE from './profile';
+
 const group: Group = {
   groupId: '1',
-  writerUid: 'test',
+  writer: PROFILE_FIXTURE,
   title: 'title',
   contents: 'contents',
   tags: [],

--- a/fixtures/initialStore.ts
+++ b/fixtures/initialStore.ts
@@ -13,7 +13,6 @@ const initialStore = {
       group: null,
       groupError: null,
       groupId: null,
-      writer: null,
       writeFields: {
         contents: '',
         title: '',

--- a/src/components/detail/DetailHeaderSection.test.tsx
+++ b/src/components/detail/DetailHeaderSection.test.tsx
@@ -11,7 +11,6 @@ describe('DetailHeaderSection', () => {
   const renderDetailHeaderSection = (group = GROUP_FIXTURE) => render((
     <DetailHeaderSection
       currentTime={given.currentTime}
-      writer={given.writer}
       group={group}
     />
   ));
@@ -59,23 +58,22 @@ describe('DetailHeaderSection', () => {
 
   describe('작성자의 프로필 이미지 섹션을 볼 수 있다', () => {
     context('작성자의 프로필 이미지가 존재하지 않는 경우', () => {
-      given('writer', () => ({
-        ...PROFILE_FIXTURE,
-        image: '',
-      }));
-
       it('"이미지 없음"이 나타나야 한다', () => {
-        const { container } = renderDetailHeaderSection();
+        const { container } = renderDetailHeaderSection({
+          ...GROUP_FIXTURE,
+          writer: {
+            ...PROFILE_FIXTURE,
+            image: '',
+          },
+        });
 
         expect(container).toHaveTextContent('이미지 없음');
       });
     });
 
     context('작성자의 프로필 이미지가 존재하는 경우', () => {
-      given('writer', () => (PROFILE_FIXTURE));
-
       it('작성자의 이미지가 나타나야 한다', () => {
-        renderDetailHeaderSection();
+        renderDetailHeaderSection(GROUP_FIXTURE);
 
         expect(screen.getByAltText('writer-img')).not.toBeNull();
       });
@@ -84,23 +82,25 @@ describe('DetailHeaderSection', () => {
 
   describe('작성자의 아이디를 볼 수 있다', () => {
     context('작성자의 이름이 존재하는 경우', () => {
-      given('writer', () => (PROFILE_FIXTURE));
-
       it('작성자의 이름이 나타나야만 한다', () => {
-        const { container } = renderDetailHeaderSection();
+        const { container } = renderDetailHeaderSection({
+          ...GROUP_FIXTURE,
+          writer: PROFILE_FIXTURE,
+        });
 
         expect(container).toHaveTextContent(PROFILE_FIXTURE.name as string);
       });
     });
 
     context('작성자의 이름이 존재하지 않는 경우', () => {
-      given('writer', () => ({
-        ...PROFILE_FIXTURE,
-        name: '',
-      }));
-
       it('작성자의 이메일이 나타나야만 한다', () => {
-        const { container } = renderDetailHeaderSection();
+        const { container } = renderDetailHeaderSection({
+          ...GROUP_FIXTURE,
+          writer: {
+            ...PROFILE_FIXTURE,
+            name: '',
+          },
+        });
 
         expect(container).toHaveTextContent(PROFILE_FIXTURE.email);
       });

--- a/src/components/detail/DetailHeaderSection.tsx
+++ b/src/components/detail/DetailHeaderSection.tsx
@@ -3,7 +3,6 @@ import React, { ReactElement } from 'react';
 import dayjs from 'dayjs';
 
 import useRecruitDateStatus from '@/hooks/useRecruitDateStatus';
-import { Profile } from '@/models/auth';
 import { Group } from '@/models/group';
 
 import 'dayjs/locale/ko';
@@ -12,26 +11,25 @@ dayjs.locale('ko');
 
 interface Props {
   group: Group;
-  writer: Profile;
   currentTime: number;
 }
 
-function DetailHeaderSection({ group, writer, currentTime }: Props): ReactElement {
-  const recruitDate = useRecruitDateStatus(group, currentTime);
+function DetailHeaderSection({ group, currentTime }: Props): ReactElement {
+  const { writer } = group;
 
-  const { image, name, email } = writer;
+  const recruitDate = useRecruitDateStatus(group, currentTime);
 
   return (
     <div>
       <h1>{group.title}</h1>
       <div>
-        {image ? (
-          <img src={image} alt="writer-img" width="50px" height="50px" />
+        {writer.image ? (
+          <img src={writer.image} alt="writer-img" width="50px" height="50px" />
         ) : (
           <div>이미지 없음</div>
         )}
         <span>
-          {name || email}
+          {writer.name || writer.email}
         </span>
         <div>
           {recruitDate}

--- a/src/containers/detail/DetailHeaderContainer.test.tsx
+++ b/src/containers/detail/DetailHeaderContainer.test.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { render } from '@testing-library/react';
 
 import GROUP_FIXTURE from '../../../fixtures/group';
-import PROFILE_FIXTURE from '../../../fixtures/profile';
 
 import DetailHeaderContainer from './DetailHeaderContainer';
 
@@ -12,7 +11,6 @@ describe('DetailHeaderContainer', () => {
     (useSelector as jest.Mock).mockImplementation((selector) => selector({
       groupReducer: {
         group: given.group,
-        writer: PROFILE_FIXTURE,
       },
     }));
   });

--- a/src/containers/detail/DetailHeaderContainer.tsx
+++ b/src/containers/detail/DetailHeaderContainer.tsx
@@ -8,16 +8,14 @@ import { getGroup } from '@/utils/utils';
 function DetailHeaderContainer(): ReactElement | null {
   const currentTime = useCurrentTime();
   const group = useSelector(getGroup('group'));
-  const writer = useSelector(getGroup('writer'));
 
-  if (!group || !writer) {
+  if (!group) {
     return null;
   }
 
   return (
     <DetailHeaderSection
       group={group}
-      writer={writer}
       currentTime={currentTime}
     />
   );

--- a/src/containers/write/PublishModalContainer.tsx
+++ b/src/containers/write/PublishModalContainer.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/client';
 
 import PublishModal from '@/components/write/PublishModal';
 import PublishModalForm from '@/components/write/PublishModalForm';
+import { Profile } from '@/models/auth';
 import { WriteFieldsForm } from '@/models/group';
 import { changeWriteFields, requestRegisterNewGroup, setPublishModalVisible } from '@/reducers/groupSlice';
 import { useAppDispatch } from '@/reducers/store';
@@ -18,7 +19,7 @@ function PublishModalContainer(): ReactElement {
 
   const onClose = useCallback(() => dispatch(setPublishModalVisible(false)), [dispatch]);
   const onSubmit = useCallback(() => dispatch(requestRegisterNewGroup(
-    session?.user.uid as string,
+    session?.user as Profile,
   )), [dispatch]);
 
   const onChangeFields = useCallback((form: WriteFieldsForm) => {

--- a/src/models/group.ts
+++ b/src/models/group.ts
@@ -1,3 +1,5 @@
+import { Profile } from './auth';
+
 export type Category = 'study' | 'project';
 export type RecruitmentEndSetting = 'manual' | 'automatic';
 
@@ -18,7 +20,7 @@ export interface Group {
   category: Category | string;
   recruitmentEndSetting: RecruitmentEndSetting;
   recruitmentEndDate: string | null;
-  writerUid: string;
+  writer: Profile;
   createAt: string;
 }
 

--- a/src/pages/api/auth/[...nextauth].api.ts
+++ b/src/pages/api/auth/[...nextauth].api.ts
@@ -30,6 +30,7 @@ export default NextAuth({
           ...session.user,
           uid: user.id,
           portfolioUrl: user.portfolioUrl,
+          position: user.position,
         },
       };
     },

--- a/src/pages/detail/[id].page.tsx
+++ b/src/pages/detail/[id].page.tsx
@@ -6,9 +6,8 @@ import { GetServerSideProps } from 'next';
 
 import DetailContentsContainer from '@/containers/detail/DetailContentsContainer';
 import DetailHeaderContainer from '@/containers/detail/DetailHeaderContainer';
-import { setGroup, setWriterProfile } from '@/reducers/groupSlice';
+import { setGroup } from '@/reducers/groupSlice';
 import wrapper from '@/reducers/store';
-import { getUserProfile } from '@/services/api/auth';
 import { getGroupDetail } from '@/services/api/group';
 
 interface Params extends ParsedUrlQuery {
@@ -33,10 +32,7 @@ export const getServerSideProps: GetServerSideProps = wrapper
       };
     }
 
-    const profile = await getUserProfile(group.writerUid);
-
     store.dispatch(setGroup(group));
-    store.dispatch(setWriterProfile(profile));
 
     return {
       props: {},

--- a/src/pages/detail/[id].test.tsx
+++ b/src/pages/detail/[id].test.tsx
@@ -5,7 +5,6 @@ import { useSelector } from 'react-redux';
 import { render } from '@testing-library/react';
 import { GetServerSidePropsContext } from 'next';
 
-import { getUserProfile } from '@/services/api/auth';
 import { getGroupDetail } from '@/services/api/group';
 
 import GROUP_FIXTURE from '../../../fixtures/group';
@@ -86,7 +85,6 @@ describe('getServerSideProps', () => {
       const response: any = await getServerSideProps(mockContext as GetServerSidePropsContext);
 
       expect(getGroupDetail).toBeCalledWith('id');
-      expect(getUserProfile).toBeCalledWith('test');
       expect(response.props.initialState.groupReducer.group).toEqual(GROUP_FIXTURE);
     });
   });

--- a/src/reducers/groupSlice.test.ts
+++ b/src/reducers/groupSlice.test.ts
@@ -21,7 +21,6 @@ import reducer, {
   setGroupId,
   setGroups,
   setPublishModalVisible,
-  setWriterProfile,
 } from './groupSlice';
 import { RootState } from './rootReducer';
 
@@ -38,7 +37,6 @@ describe('groupReducer', () => {
     groupId: null,
     groupError: null,
     writeFields: WRITE_FIELDS_FIXTURE,
-    writer: null,
     isVisible: false,
   };
 
@@ -123,14 +121,6 @@ describe('groupReducer', () => {
       expect(isVisible).toBeTruthy();
     });
   });
-
-  describe('setWriterProfile', () => {
-    it('writer 정보가 반환되어야만 한다', () => {
-      const { writer } = reducer(initialState, setWriterProfile(PROFILE_FIXTURE));
-
-      expect(writer).toBe(PROFILE_FIXTURE);
-    });
-  });
 });
 
 describe('groupReducer async actions', () => {
@@ -153,7 +143,7 @@ describe('groupReducer async actions', () => {
       (postNewGroup as jest.Mock).mockReturnValueOnce('1');
 
       it('dispatch 액션이 "group/setGroupId"인 타입과 group id 이어야 한다', async () => {
-        await store.dispatch(requestRegisterNewGroup('userUid'));
+        await store.dispatch(requestRegisterNewGroup(PROFILE_FIXTURE));
 
         const actions = store.getActions();
 
@@ -175,7 +165,7 @@ describe('groupReducer async actions', () => {
 
       it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
         try {
-          await store.dispatch(requestRegisterNewGroup('userUid'));
+          await store.dispatch(requestRegisterNewGroup(PROFILE_FIXTURE));
         } catch (error) {
           // ignore errors
         } finally {

--- a/src/reducers/groupSlice.ts
+++ b/src/reducers/groupSlice.ts
@@ -15,7 +15,6 @@ export interface GroupStore {
   group: Group | null;
   groupError: string | null;
   writeFields: WriteFields;
-  writer: Profile | null;
   groupId: string | null;
   isVisible: boolean;
 }
@@ -37,7 +36,6 @@ const { actions, reducer } = createSlice({
     groupId: null,
     groupError: null,
     writeFields: initialFieldsState,
-    writer: null,
     isVisible: false,
   } as GroupStore,
   reducers: {
@@ -86,12 +84,6 @@ const { actions, reducer } = createSlice({
         isVisible,
       };
     },
-    setWriterProfile(state, { payload: writer }: PayloadAction<Profile>) {
-      return {
-        ...state,
-        writer,
-      };
-    },
   },
 });
 
@@ -101,18 +93,17 @@ export const {
   setGroupId,
   setGroupError,
   clearWriteFields,
-  setWriterProfile,
   changeWriteFields,
   setPublishModalVisible,
 } = actions;
 
 export const requestRegisterNewGroup = (
-  userUid: string,
+  profile: Profile,
 ): AppThunk => async (dispatch, getStore) => {
   const { groupReducer } = getStore();
 
   try {
-    const groupId = await postNewGroup(userUid, groupReducer.writeFields);
+    const groupId = await postNewGroup(profile, groupReducer.writeFields);
 
     dispatch(setGroupId(groupId));
     dispatch(setPublishModalVisible(false));

--- a/src/reducers/rootReducer.test.ts
+++ b/src/reducers/rootReducer.test.ts
@@ -29,7 +29,6 @@ describe('rootReducer', () => {
       groupId: null,
       groupError: null,
       writeFields: fieldsInitialState,
-      writer: null,
       isVisible: false,
     },
   };

--- a/src/reducers/store.ts
+++ b/src/reducers/store.ts
@@ -21,12 +21,13 @@ const store = makeStore();
 export type AppStore = ReturnType<typeof makeStore>;
 export type AppState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
-export const useAppDispatch = () => useDispatch<AppDispatch>();
 export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
   AppState,
   unknown,
   Action<string>
 >
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
 
 export default wrapper;

--- a/src/services/api/group.test.ts
+++ b/src/services/api/group.test.ts
@@ -1,6 +1,7 @@
 import { WriteFields } from '@/models/group';
 import { getGroupDetail, getGroups, postNewGroup } from '@/services/api/group';
 
+import PROFILE_FIXTURE from '../../../fixtures/profile';
 import db, { fireStore } from '../firebase';
 
 jest.mock('@/utils/firestore');
@@ -13,7 +14,6 @@ describe('group API', () => {
   describe('updateUserProfile', () => {
     const mockAdd = jest.fn().mockReturnValueOnce({ id: '1' });
     const createAt = '2021-11-11';
-    const userUid = 'userUid';
 
     const group: WriteFields = {
       title: 'title',
@@ -35,11 +35,11 @@ describe('group API', () => {
     });
 
     it('update 함수가 호출되어야만 한다', async () => {
-      const id = await postNewGroup(userUid, group);
+      const id = await postNewGroup(PROFILE_FIXTURE, group);
 
       expect(mockAdd).toBeCalledWith({
         ...group,
-        writerUid: userUid,
+        writer: PROFILE_FIXTURE,
         createAt,
       });
       expect(id).toBe('1');

--- a/src/services/api/group.ts
+++ b/src/services/api/group.ts
@@ -1,12 +1,13 @@
+import { Profile } from '@/models/auth';
 import { Category, Group, WriteFields } from '@/models/group';
 import { timestampToString } from '@/utils/firestore';
 
 import { collection, fireStore } from '../firebase';
 
-export const postNewGroup = async (writerUid: string, fields: WriteFields) => {
+export const postNewGroup = async (profile: Profile, fields: WriteFields) => {
   const { id } = await collection('groups').add({
     ...fields,
-    writerUid,
+    writer: profile,
     createAt: fireStore.FieldValue.serverTimestamp(),
   });
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -11,6 +11,7 @@ declare module 'next-auth' {
       email: string;
       image?: string | null;
       portfolioUrl?: string | null;
+      position?: string | null;
     },
   }
 
@@ -20,5 +21,6 @@ declare module 'next-auth' {
     email: string;
     image?: string | null;
     portfolioUrl?: string | null;
+    position?: string | null;
   }
 }


### PR DESCRIPTION
- 기존에 writerUid로 작성자 정보를 조회했다. 생각보다 이렇게 했을 때 firestore 구조에서는 리스트에서 모든 작성자 정보를 다시 또 조회를 해야한다.
- writer user profile 정보를 글 작성시 모두 입력