### PR TITLE
[Feature] 디자인 시스템에 맞춰 버튼 공통 컴포넌트를 구현하라

### DIFF
--- a/src/components/common/Button.test.tsx
+++ b/src/components/common/Button.test.tsx
@@ -1,0 +1,91 @@
+import { ComponentProps } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import palette from '@/styles/palette';
+
+import Button from './Button';
+
+describe('Button', () => {
+  const renderButton = ({ color, size, href }: ComponentProps<typeof Button>) => render((
+    <Button
+      color={color}
+      size={size}
+      href={href}
+    >
+      버튼
+    </Button>
+  ));
+
+  describe('버튼 사이즈에 따라서 스타일 속성이 다르다', () => {
+    context('사이즈가 "large"인 경우', () => {
+      it('폰트 사이즈가 "17px"이어야만 한다', () => {
+        renderButton({ size: 'large' });
+
+        expect(screen.getByText('버튼')).toHaveStyle({
+          'font-size': '17px',
+        });
+      });
+    });
+
+    context('사이즈가 "medium"인 경우', () => {
+      it('폰트 사이즈가 "15px"이어야만 한다', () => {
+        renderButton({ size: 'medium' });
+
+        expect(screen.getByText('버튼')).toHaveStyle({
+          'font-size': '15px',
+        });
+      });
+    });
+
+    context('사이즈가 "small"인 경우', () => {
+      it('폰트 사이즈가 "0.875rem"이어야만 한다', () => {
+        renderButton({ size: 'small' });
+
+        expect(screen.getByText('버튼')).toHaveStyle({
+          'font-size': '0.875rem',
+        });
+      });
+    });
+  });
+
+  describe('버튼 색상 속성에 따라서 스타일 속성이 다르다', () => {
+    context('색상 속성이 "outlined"인 경우', () => {
+      it(`색상이 ${palette.foreground} 이어야만 한다`, () => {
+        renderButton({ color: 'outlined' });
+
+        expect(screen.getByText('버튼')).toHaveStyle({
+          color: palette.foreground,
+        });
+      });
+    });
+
+    context('색상 속성이 "primary"인 경우', () => {
+      it(`색상이 ${palette.background} 이어야만 한다`, () => {
+        renderButton({ color: 'primary' });
+
+        expect(screen.getByText('버튼')).toHaveStyle({
+          color: palette.background,
+        });
+      });
+    });
+  });
+
+  describe('"href" 속성 유무에 따라 버튼 또는 링크가 나타난다', () => {
+    context('버튼인 경우', () => {
+      it('"href" 속성이 없어야만 한다', () => {
+        renderButton({});
+
+        expect(screen.getByText('버튼')).not.toHaveAttribute('href', '/test');
+      });
+    });
+
+    context('링크인 경우', () => {
+      it('링크 정보가 나타나야만 한다', () => {
+        renderButton({ href: '/test' });
+
+        expect(screen.getByText('버튼')).toHaveAttribute('href', '/test');
+      });
+    });
+  });
+});

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { HTMLProps, PropsWithChildren, ReactElement } from 'react';
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import Link from 'next/link';
+
+import palette from '@/styles/palette';
+
+type ColorType = 'primary' | 'outlined';
+type ButtonSize = 'small' | 'medium' | 'large';
+
+interface Props extends Omit<HTMLProps<HTMLButtonElement | HTMLAnchorElement>, 'size'> {
+  color?: ColorType;
+  size?: ButtonSize;
+}
+
+interface StyledButtonProps {
+  color: ColorType;
+  size: ButtonSize;
+}
+
+function Button({
+  color = 'outlined', size = 'medium', href, children, ...rest
+}: PropsWithChildren<Props>): ReactElement {
+  const htmlProps = rest as any;
+
+  if (href) {
+    return (
+      <Link href={href} passHref>
+        <StyledLink
+          color={color}
+          size={size}
+          {...htmlProps}
+        >
+          {children}
+        </StyledLink>
+      </Link>
+    );
+  }
+
+  return (
+    <StyledButton
+      color={color}
+      size={size}
+      {...htmlProps}
+    >
+      {children}
+    </StyledButton>
+  );
+}
+
+export default Button;
+
+const ButtonWrapper = ({ color, size }: StyledButtonProps) => css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 1rem;
+  font-weight: 600;
+  border-radius: 6px;
+  transition: all .3s;
+
+  ${size === 'large' && css`
+    font-size: 17px;
+    line-height: 24px;
+    height: 48px;
+    padding: 0;
+    border-radius: 8px;
+    width: 320px;
+  `};
+
+  ${size === 'medium' && css`
+    font-size: 15px;
+    line-height: 24px;
+    height: 36px;
+  `};
+
+  ${size === 'small' && css`
+    font-size: 0.875rem;
+    line-height: 22px;
+    height: 32px;
+  `};
+
+  ${color === 'outlined' && css`
+    color: ${palette.foreground};
+    background: ${palette.background};
+    border: 1px solid ${palette.accent2};
+
+    &:hover {
+      background: ${palette.accent2};
+      border: 1px solid ${palette.accent3};
+    }
+
+    &:disabled {
+      color: ${palette.accent4};
+      background: ${palette.accent1};
+      border: 1px solid ${palette.accent1};
+    }
+  `}
+
+  ${color === 'primary' && css`
+    color: ${palette.background};
+    background: ${palette.success};
+
+    &:hover {
+      color: ${palette.accent2};
+      background: ${palette.success10};
+    }
+
+    &:disabled {
+      color: ${palette.accent4};
+      background: ${palette.accent1};
+    }
+  `}
+`;
+
+const StyledLink = styled.a<StyledButtonProps>`
+  ${ButtonWrapper}
+`;
+
+const StyledButton = styled.button<StyledButtonProps>`
+  ${ButtonWrapper}
+`;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -11,6 +11,7 @@ import zIndexes from '@/styles/zIndexes';
 
 import LogoSvg from '../../assets/icons/img_logo_conners.svg';
 
+import Button from './Button';
 import ProfileImage from './ProfileImage';
 
 interface Props {
@@ -29,23 +30,33 @@ function Header({ session, onClick, isScrollTop }: Props): ReactElement {
               <LogoIcon />
             </a>
           </Link>
-          <div>
-            {session ? (
-              <>
-                <Link href="/write" passHref>
-                  <a>팀 모집하기</a>
-                </Link>
-                <ProfileImage src={session.user?.image} />
-                <button type="button" onClick={() => signOut()}>
-                  로그아웃
-                </button>
-              </>
-            ) : (
-              <button type="button" onClick={onClick}>
-                시작하기
-              </button>
-            )}
-          </div>
+          {session ? (
+            <UserNavWrapper>
+              <Button
+                size="small"
+                href="/write"
+              >
+                팀 모집하기
+              </Button>
+              <ProfileImage src={session.user?.image} />
+              <Button
+                size="small"
+                type="button"
+                onClick={() => signOut()}
+              >
+                로그아웃
+              </Button>
+            </UserNavWrapper>
+          ) : (
+            <Button
+              color="primary"
+              size="small"
+              type="button"
+              onClick={onClick}
+            >
+              시작하기
+            </Button>
+          )}
         </HeaderWrapper>
       </HeaderBlock>
       <Spacer />
@@ -67,6 +78,15 @@ const HeaderBlock = styled.div<{isScrollTop: boolean }>`
   background: ${palette.accent1};
   box-shadow: inset 0 -1px 0 0 ${({ isScrollTop }) => (isScrollTop ? 'transparent' : palette.accent4)};
   transition: box-shadow .2s ease-in-out;
+`;
+
+const UserNavWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  & a:first-of-type {
+    margin-right: 24px;
+  }
 `;
 
 const Spacer = styled.div`

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -1,0 +1,27 @@
+import Document, {
+  DocumentContext, Head, Html, Main, NextScript,
+} from 'next/document';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx);
+
+    return initialProps;
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -9,7 +9,23 @@ const setGlobalStyles = () => css`
   ${emotionNormalize}
 
   body {
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
     background: ${palette.accent1};
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  button {
+    outline: none;
+    cursor: pointer;
+    border: unset;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
 `;
 


### PR DESCRIPTION
- Size: small, medium, large
- color: primary, outlined
- Link와 Button 둘을 추상화하여 공통 컴포넌트로 구현
- hover, disabled, default
- Pretendard 폰트 적용

Outlined, Highlighted
<img width="153" alt="스크린샷 2021-12-25 오후 10 49 24" src="https://user-images.githubusercontent.com/60910665/147386468-857f9ed5-78fd-4cef-9483-3ddae8bf1ad2.png">

Outlined, Default 
<img width="153" alt="스크린샷 2021-12-25 오후 10 49 14" src="https://user-images.githubusercontent.com/60910665/147386469-58c9065f-075c-4a8e-ab0d-1126477aff92.png">

primary, Large
<img width="391" alt="스크린샷 2021-12-25 오후 10 48 56" src="https://user-images.githubusercontent.com/60910665/147386471-9faa72ba-e8c1-45b0-acb0-107fbeeae1c8.png">

disabled
<img width="167" alt="스크린샷 2021-12-25 오후 10 48 25" src="https://user-images.githubusercontent.com/60910665/147386472-4866e309-7fad-4e7e-924e-1c4d9553ca2f.png">

primary, medium
<img width="167" alt="스크린샷 2021-12-25 오후 10 48 14" src="https://user-images.githubusercontent.com/60910665/147386473-81569bfa-fdcf-4698-aa30-ea0cf6b0607c.png">

primary, small 
<img width="167" alt="스크린샷 2021-12-25 오후 10 47 49" src="https://user-images.githubusercontent.com/60910665/147386477-0f1976d5-1da4-49c0-9a90-ebcbd3e3d3b7.png">

primary, Highlighted
<img width="167" alt="스크린샷 2021-12-25 오후 10 47 56" src="https://user-images.githubusercontent.com/60910665/147386475-57ee09b6-1a50-4cf6-bd73-cfdc77f4fb17.png">

