### PR TITLE
[Feature] 로그인 후 헤더 Navbar의 프로필 드롭다운 구현하라

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,6 +112,7 @@ module.exports = {
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-duplicates': 'error',
+    'no-undef': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
     'unused-imports/no-unused-imports': 'error',
     'unused-imports/no-unused-vars': [

--- a/src/components/common/DropDown.test.tsx
+++ b/src/components/common/DropDown.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { signOut } from 'next-auth/client';
+
+import DropDown from './DropDown';
+
+describe('DropDown', () => {
+  const renderDropDown = () => render((
+    <DropDown
+      isVisible={given.isVisible}
+    />
+  ));
+
+  context('isVisible이 true인 경우', () => {
+    given('isVisible', () => true);
+
+    describe('로그아웃 버튼을 클릭한다', () => {
+      it('로그아웃 이벤트가 호출되어야만 한다', () => {
+        renderDropDown();
+
+        fireEvent.click(screen.getByText('로그아웃'));
+
+        expect(signOut).toBeCalledTimes(1);
+      });
+    });
+  });
+
+  context('isVisible이 false인 경우', () => {
+    given('isVisible', () => false);
+
+    it('아무것도 렌더링 되지 않아야 한다', () => {
+      const { container } = renderDropDown();
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/components/common/DropDown.tsx
+++ b/src/components/common/DropDown.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from 'react';
+
+import styled from '@emotion/styled';
+import { signOut } from 'next-auth/client';
+
+import palette from '../../styles/palette';
+
+interface Props {
+  isVisible: boolean;
+}
+
+function DropDown({ isVisible }: Props):ReactElement | null {
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <DropDownWrapper>
+      <div className="menu-wrapper">
+        <MenuContent>
+          내 정보
+        </MenuContent>
+        <MenuContent
+          onClick={() => signOut()}
+        >
+          로그아웃
+        </MenuContent>
+      </div>
+    </DropDownWrapper>
+  );
+}
+
+export default DropDown;
+
+const DropDownWrapper = styled.div`
+  position: absolute;
+  top: 100%;
+
+  .menu-wrapper {
+    position: relative;
+    z-index: 5;
+    width: 10rem;
+    background: ${palette.accent2};
+    box-shadow: rgb(0 0 0 / 20%) 0px 0px 8px;
+  }
+`;
+
+const MenuContent = styled.div`
+  color: ${palette.foreground};
+  padding: 0.75rem 1rem;
+  line-height: 1.5;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color .2s;
+  
+  &:hover {
+    background: ${palette.accent3};
+  }
+`;

--- a/src/components/common/Header.test.tsx
+++ b/src/components/common/Header.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { signOut } from 'next-auth/client';
 
 import palette from '@/styles/palette';
 
@@ -52,21 +51,10 @@ describe('Header', () => {
       },
     }));
 
-    it('"로그아웃" 버튼과 "팀 모집하기" 링크가 나타나야만 한다', () => {
-      const { container } = renderHeader();
+    it('"팀 모집하기" 링크가 나타나야만 한다', () => {
+      renderHeader();
 
-      expect(container).toHaveTextContent('로그아웃');
       expect(screen.getByText('팀 모집하기')).toHaveAttribute('href', '/write');
-    });
-
-    describe('"로그아웃" 버튼을 클릭한다', () => {
-      it('클릭 이벤트가 호출되어야만 한다', () => {
-        renderHeader();
-
-        fireEvent.click(screen.getByText('로그아웃'));
-
-        expect(signOut).toBeCalledTimes(1);
-      });
     });
   });
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -3,7 +3,6 @@ import React, { ReactElement } from 'react';
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { Session } from 'next-auth';
-import { signOut } from 'next-auth/client';
 
 import Layout from '@/styles/Layout';
 import palette from '@/styles/palette';
@@ -12,7 +11,7 @@ import zIndexes from '@/styles/zIndexes';
 import LogoSvg from '../../assets/icons/img_logo_conners.svg';
 
 import Button from './Button';
-import ProfileImage from './ProfileImage';
+import UserNavbar from './UserNavbar';
 
 interface Props {
   session: Session | null
@@ -31,22 +30,9 @@ function Header({ session, onClick, isScrollTop }: Props): ReactElement {
             </a>
           </Link>
           {session ? (
-            <UserNavWrapper>
-              <Button
-                size="small"
-                href="/write"
-              >
-                팀 모집하기
-              </Button>
-              <ProfileImage src={session.user?.image} />
-              <Button
-                size="small"
-                type="button"
-                onClick={() => signOut()}
-              >
-                로그아웃
-              </Button>
-            </UserNavWrapper>
+            <UserNavbar
+              userImage={session.user.image}
+            />
           ) : (
             <Button
               color="primary"
@@ -78,15 +64,6 @@ const HeaderBlock = styled.div<{isScrollTop: boolean }>`
   background: ${palette.accent1};
   box-shadow: inset 0 -1px 0 0 ${({ isScrollTop }) => (isScrollTop ? 'transparent' : palette.accent4)};
   transition: box-shadow .2s ease-in-out;
-`;
-
-const UserNavWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-
-  & a:first-of-type {
-    margin-right: 24px;
-  }
 `;
 
 const Spacer = styled.div`

--- a/src/components/common/ProfileImage.tsx
+++ b/src/components/common/ProfileImage.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import DefaultAvatarSvg from '../../assets/icons/img_avatar_default.svg';
@@ -8,11 +9,20 @@ interface Props {
   src?: string | null;
   alt?: string;
   size?: string;
+  onClick?: () => void;
 }
 
-function ProfileImage({ src, alt = 'profile', size = '32px' }: Props): ReactElement {
+function ProfileImage({
+  src, alt = 'profile', size = '32px', onClick,
+}: Props): ReactElement {
   if (!src) {
-    return <DefaultAvatarIcon size={size} data-testid="default-profile-icon" />;
+    return (
+      <DefaultAvatarIcon
+        size={size}
+        data-testid="default-profile-icon"
+        onClick={onClick}
+      />
+    );
   }
 
   return (
@@ -21,6 +31,7 @@ function ProfileImage({ src, alt = 'profile', size = '32px' }: Props): ReactElem
       alt={alt}
       width={size}
       height={size}
+      onClick={onClick}
     />
   );
 }
@@ -30,9 +41,16 @@ export default ProfileImage;
 const DefaultAvatarIcon = styled(DefaultAvatarSvg)`
   width: ${({ size }) => size};
   height: ${({ size }) => size};
+
+  ${({ onClick }) => onClick && css`
+    cursor: pointer;
+  `};
 `;
 
 const ProfileAvatarImage = styled.img`
   border-radius: 70%;
   overflow: hidden;
+  ${({ onClick }) => onClick && css`
+    cursor: pointer;
+  `};
 `;

--- a/src/components/common/UserNavbar.test.tsx
+++ b/src/components/common/UserNavbar.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import UserNavbar from './UserNavbar';
+
+describe('UserNavbar', () => {
+  const renderUserNavbar = () => render((
+    <UserNavbar />
+  ));
+
+  it('"팀 모집하기" 링크가 나타나야만 한다', () => {
+    renderUserNavbar();
+
+    expect(screen.getByText('팀 모집하기')).toHaveAttribute('href', '/write');
+  });
+
+  context('dropdown 메뉴가 보이지 않는 경우', () => {
+    describe('프로필 이미지를 클릭한다', () => {
+      it('dropdown 메뉴가 나타나야만 한다', () => {
+        const { container } = renderUserNavbar();
+
+        expect(container).not.toHaveTextContent('로그아웃');
+
+        fireEvent.click(screen.getByTestId('default-profile-icon'));
+
+        expect(container).toHaveTextContent('로그아웃');
+      });
+    });
+  });
+
+  context('dropdown 메뉴가 보이는 경우', () => {
+    describe('dropdown 밖에 부분을 클릭한다', () => {
+      it('dropdown 메뉴가 사라져야만 한다', () => {
+        const { container } = renderUserNavbar();
+
+        fireEvent.click(screen.getByTestId('default-profile-icon'));
+
+        fireEvent.mouseDown(document);
+
+        expect(container).not.toHaveTextContent('로그아웃');
+      });
+    });
+
+    describe('스크롤이 액션이 일어난다', () => {
+      it('dropdown 메뉴가 사라져야만 한다', () => {
+        const { container } = renderUserNavbar();
+
+        fireEvent.click(screen.getByTestId('default-profile-icon'));
+
+        fireEvent.scroll(document);
+
+        expect(container).not.toHaveTextContent('로그아웃');
+      });
+    });
+
+    describe('dropdown 메뉴 안 "로그아웃" 버튼을 클릭한다', () => {
+      it('dropdown는 사라지지 않아야 한다', () => {
+        const { container } = renderUserNavbar();
+
+        fireEvent.click(screen.getByTestId('default-profile-icon'));
+
+        fireEvent.mouseDown(screen.getByText('로그아웃'));
+
+        expect(container).toHaveTextContent('로그아웃');
+      });
+    });
+  });
+});

--- a/src/components/common/UserNavbar.tsx
+++ b/src/components/common/UserNavbar.tsx
@@ -1,0 +1,78 @@
+import React, {
+  ReactElement, useCallback, useEffect, useRef, useState,
+} from 'react';
+import { useUnmount } from 'react-use';
+
+import styled from '@emotion/styled';
+
+import Button from './Button';
+import DropDown from './DropDown';
+import ProfileImage from './ProfileImage';
+
+interface Props {
+  userImage?: string | null;
+}
+
+function UserNavbar({ userImage }: Props): ReactElement {
+  const [isVisible, setVisible] = useState<boolean>(false);
+  const userIconRef = useRef<HTMLDivElement>(null);
+
+  const handleDropdownOutside = useCallback((e) => {
+    if (!userIconRef.current) {
+      return;
+    }
+
+    if (userIconRef.current === e.target || userIconRef.current.contains(e.target)) {
+      return;
+    }
+
+    setVisible(false);
+  }, [userIconRef]);
+
+  const addEventDropdown = useCallback((event: keyof DocumentEventMap) => {
+    document.addEventListener(event, handleDropdownOutside);
+  }, [handleDropdownOutside]);
+
+  useEffect(() => {
+    addEventDropdown('scroll');
+    addEventDropdown('mousedown');
+  }, [addEventDropdown]);
+
+  useUnmount(() => {
+    addEventDropdown('scroll');
+    addEventDropdown('mousedown');
+  });
+
+  return (
+    <UserNavbarWrapper>
+      <Button
+        size="small"
+        href="/write"
+      >
+        팀 모집하기
+      </Button>
+      <div className="profile-dropdown-wrapper" ref={userIconRef}>
+        <ProfileImage
+          src={userImage}
+          onClick={() => setVisible(!isVisible)}
+        />
+        <DropDown isVisible={isVisible} />
+      </div>
+    </UserNavbarWrapper>
+  );
+}
+
+export default UserNavbar;
+
+const UserNavbarWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  & a:first-of-type {
+    margin-right: 24px;
+  }
+
+  .profile-dropdown-wrapper {
+    display: contents;
+  }
+`;

--- a/src/containers/common/HeaderContainer.test.tsx
+++ b/src/containers/common/HeaderContainer.test.tsx
@@ -52,10 +52,10 @@ describe('HeaderContainer', () => {
   context('로그인한 경우', () => {
     given('session', () => (SESSION_FIXTURE));
 
-    it('"로그아웃" 버튼이 나타나야만 한다', () => {
+    it('"팀 모집하기" 버튼이 나타나야만 한다', () => {
       const { container } = renderHeaderContainer();
 
-      expect(container).toHaveTextContent('로그아웃');
+      expect(container).toHaveTextContent('팀 모집하기');
     });
   });
 


### PR DESCRIPTION
- 로그인 후 헤더 Navbar의 프로필 드롭다운 구현하기
- 드롭다운 메뉴 구현
    - 로그아웃, 내정보

<img width="183" alt="스크린샷 2021-12-26 오후 5 00 06" src="https://user-images.githubusercontent.com/60910665/147402447-4e3e873d-3174-4ed7-9434-2d7b81fd4de7.png">

