### PR TITLE
[Improve] 조건에 따라 디테일 페이지의 버튼 및 날짜 상태가 다르게 나타나게하라

### DIFF
--- a/src/components/detail/ApplicantStatusButton.test.tsx
+++ b/src/components/detail/ApplicantStatusButton.test.tsx
@@ -23,6 +23,7 @@ describe('ApplicantStatusButton', () => {
       onVisibleSignInModal={handleVisibleSignInModal}
       applicant={given.applicant}
       user={given.user}
+      isRecruiting={given.isRecruiting}
       onCancelApply={handleCancelApply}
     />
   ));
@@ -30,103 +31,117 @@ describe('ApplicantStatusButton', () => {
   context('isCompleted가 false인 경우', () => {
     given('isCompleted', () => false);
 
-    context('"applicant"가 존재하지 않는 경우', () => {
-      given('applicant', () => false);
+    context('isRecruiting이 true인 경우', () => {
+      given('isRecruiting', () => true);
 
-      it('"신청하기"버튼이 보여야만 한다', () => {
-        const { container } = renderApplicantStatusButton();
+      context('"applicant"가 존재하지 않는 경우', () => {
+        given('applicant', () => false);
 
-        expect(container).toHaveTextContent('신청하기');
-      });
+        it('"신청하기"버튼이 보여야만 한다', () => {
+          const { container } = renderApplicantStatusButton();
 
-      describe('"신청하기" 버튼을 클릭한다', () => {
-        context('사용자가 로그인한 경우', () => {
-          given('user', () => PROFILE_FIXTURE);
+          expect(container).toHaveTextContent('신청하기');
+        });
 
-          it('신청 폼 모달창이 나타난다', () => {
-            const { container } = renderApplicantStatusButton();
+        describe('"신청하기" 버튼을 클릭한다', () => {
+          context('사용자가 로그인한 경우', () => {
+            given('user', () => PROFILE_FIXTURE);
 
-            fireEvent.click(screen.getByText('신청하기'));
-
-            expect(container).toHaveTextContent(/신청/);
-          });
-
-          describe('신청 모달창에서 "신청하기"를 클릭한다', () => {
-            it('클릭 이벤트가 호출되어야만 한다', async () => {
+            it('신청 폼 모달창이 나타난다', () => {
               const { container } = renderApplicantStatusButton();
 
               fireEvent.click(screen.getByText('신청하기'));
-              await act(async () => {
-                await fireEvent.change(screen.getByPlaceholderText('간단한 소개글을 입력하세요'), {
-                  target: { value: 'test' },
-                });
-                fireEvent.submit(screen.getByTestId('apply-button'));
-              });
 
-              expect(handleApply).toBeCalledTimes(1);
-              expect(container).not.toHaveTextContent(/소개글/);
+              expect(container).toHaveTextContent(/신청/);
+            });
+
+            describe('신청 모달창에서 "신청하기"를 클릭한다', () => {
+              it('클릭 이벤트가 호출되어야만 한다', async () => {
+                const { container } = renderApplicantStatusButton();
+
+                fireEvent.click(screen.getByText('신청하기'));
+                await act(async () => {
+                  await fireEvent.change(screen.getByPlaceholderText('간단한 소개글을 입력하세요'), {
+                    target: { value: 'test' },
+                  });
+                  fireEvent.submit(screen.getByTestId('apply-button'));
+                });
+
+                expect(handleApply).toBeCalledTimes(1);
+                expect(container).not.toHaveTextContent(/소개글/);
+              });
+            });
+
+            describe('신청 모달창에서 "닫기" 버튼을 클릭한다', () => {
+              it('모달창이 나타나지 않아야한다', async () => {
+                const { container } = renderApplicantStatusButton();
+
+                fireEvent.click(screen.getByText('신청하기'));
+                fireEvent.click(screen.getByText('닫기'));
+
+                expect(container).not.toHaveTextContent(/소개글/);
+              });
             });
           });
 
-          describe('신청 모달창에서 "닫기" 버튼을 클릭한다', () => {
-            it('모달창이 나타나지 않아야한다', async () => {
-              const { container } = renderApplicantStatusButton();
+          context('사용자가 로그인하지 않은 경우', () => {
+            given('user', () => null);
+
+            it('visibleSignInModal 이벤트가 발생해야만 한다', () => {
+              renderApplicantStatusButton();
 
               fireEvent.click(screen.getByText('신청하기'));
-              fireEvent.click(screen.getByText('닫기'));
 
-              expect(container).not.toHaveTextContent(/소개글/);
+              expect(handleVisibleSignInModal).toBeCalledTimes(1);
             });
           });
         });
+      });
 
-        context('사용자가 로그인하지 않은 경우', () => {
-          given('user', () => null);
+      context('"applicant"가 존재하는 경우', () => {
+        given('applicant', () => APPLICANT_FIXTURE);
 
-          it('visibleSignInModal 이벤트가 발생해야만 한다', () => {
+        describe('"신청 취소" 버튼을 클릭한다', () => {
+          it('신청 취소 모달창이 나타나야만 한다', () => {
+            const { container } = renderApplicantStatusButton();
+
+            fireEvent.click(screen.getByText('신청 취소'));
+
+            expect(container).toHaveTextContent(/신청 취소하기/);
+          });
+        });
+
+        describe('신청 취소 모달창에서 "닫기" 버튼을 클릭한다', () => {
+          it('신청 취소 모달창이 안보여야만 한다', () => {
+            const { container } = renderApplicantStatusButton();
+
+            fireEvent.click(screen.getByText('신청 취소'));
+            fireEvent.click(screen.getByText('닫기'));
+
+            expect(container).not.toHaveTextContent(/신청 취소하기/);
+          });
+        });
+
+        describe('신청 취소 모달창에서 "취소하기" 버튼을 클릭한다', () => {
+          it('클릭 이벤트가 발생해야만 한다', () => {
             renderApplicantStatusButton();
 
-            fireEvent.click(screen.getByText('신청하기'));
+            fireEvent.click(screen.getByText('신청 취소'));
+            fireEvent.click(screen.getByText('취소하기'));
 
-            expect(handleVisibleSignInModal).toBeCalledTimes(1);
+            expect(handleCancelApply).toBeCalledWith('2');
           });
         });
       });
     });
 
-    context('"applicant"가 존재하는 경우', () => {
-      given('applicant', () => APPLICANT_FIXTURE);
+    context('isRecruiting이 false인 경우', () => {
+      given('isRecruiting', () => false);
 
-      describe('"신청 취소" 버튼을 클릭한다', () => {
-        it('신청 취소 모달창이 나타나야만 한다', () => {
-          const { container } = renderApplicantStatusButton();
+      it('아무것도 렌더링되지 않아야만 한다', () => {
+        const { container } = renderApplicantStatusButton();
 
-          fireEvent.click(screen.getByText('신청 취소'));
-
-          expect(container).toHaveTextContent(/신청 취소하기/);
-        });
-      });
-
-      describe('신청 취소 모달창에서 "닫기" 버튼을 클릭한다', () => {
-        it('신청 취소 모달창이 안보여야만 한다', () => {
-          const { container } = renderApplicantStatusButton();
-
-          fireEvent.click(screen.getByText('신청 취소'));
-          fireEvent.click(screen.getByText('닫기'));
-
-          expect(container).not.toHaveTextContent(/신청 취소하기/);
-        });
-      });
-
-      describe('신청 취소 모달창에서 "취소하기" 버튼을 클릭한다', () => {
-        it('클릭 이벤트가 발생해야만 한다', () => {
-          renderApplicantStatusButton();
-
-          fireEvent.click(screen.getByText('신청 취소'));
-          fireEvent.click(screen.getByText('취소하기'));
-
-          expect(handleCancelApply).toBeCalledWith('2');
-        });
+        expect(container).toBeEmptyDOMElement();
       });
     });
   });

--- a/src/components/detail/ApplicantStatusButton.tsx
+++ b/src/components/detail/ApplicantStatusButton.tsx
@@ -15,11 +15,12 @@ interface Props {
   onVisibleSignInModal: () => void;
   applicant?: Applicant;
   onCancelApply: (applicantId: string) => void;
+  isRecruiting: boolean;
 }
 
 function ApplicantStatusButton({
-  isCompleted, onApply, user, onVisibleSignInModal, applicant, onCancelApply,
-}: Props): ReactElement {
+  isCompleted, onApply, user, onVisibleSignInModal, applicant, onCancelApply, isRecruiting,
+}: Props): ReactElement | null {
   const [isVisibleApplyModal, setIsVisibleApplyModal] = useState<boolean>(false);
   const [isVisibleCancelModal, setIsVisibleCancelModal] = useState<boolean>(false);
 
@@ -45,6 +46,10 @@ function ApplicantStatusButton({
     );
   }
 
+  if (!isRecruiting) {
+    return null;
+  }
+
   if (applicant) {
     return (
       <>
@@ -53,7 +58,10 @@ function ApplicantStatusButton({
         </Button>
         <AskApplyCancelModal
           onClose={() => setIsVisibleCancelModal(false)}
-          onCancel={() => onCancelApply(applicant.uid)}
+          onCancel={() => {
+            onCancelApply(applicant.uid);
+            setIsVisibleCancelModal(false);
+          }}
           isVisible={isVisibleCancelModal}
         />
       </>

--- a/src/components/detail/DetailHeaderSection.test.tsx
+++ b/src/components/detail/DetailHeaderSection.test.tsx
@@ -10,7 +10,6 @@ describe('DetailHeaderSection', () => {
   const renderDetailHeaderSection = (group = GROUP_FIXTURE) => render((
     <DetailHeaderSection
       group={group}
-      currentTime={given.currentTime}
     />
   ));
 
@@ -42,13 +41,13 @@ describe('DetailHeaderSection', () => {
     context('모집 마감 일자가 현재 시간 이전인 경우', () => {
       given('currentTime', () => Date.now());
 
-      it('"모집 마감"이 나타나야만 한다', () => {
+      it('글 작성 일자가 나타나야만 한다', () => {
         const { container } = renderDetailHeaderSection({
           ...GROUP_FIXTURE,
           recruitmentEndDate: yesterday(new Date()),
         });
 
-        expect(container).toHaveTextContent(/모집 마감/);
+        expect(container).toHaveTextContent('2021년 10월 11일');
       });
     });
   });

--- a/src/components/detail/DetailHeaderSection.tsx
+++ b/src/components/detail/DetailHeaderSection.tsx
@@ -4,6 +4,7 @@ import { Eye as ViewsIcon } from 'react-feather';
 import styled from '@emotion/styled';
 import dayjs from 'dayjs';
 
+import useCurrentTime from '@/hooks/useCurrentTime';
 import useRecruitDateStatus from '@/hooks/useRecruitDateStatus';
 import { Group } from '@/models/group';
 import Divider from '@/styles/Divider';
@@ -19,14 +20,14 @@ dayjs.locale('ko');
 
 interface Props {
   group: Group;
-  currentTime: number;
 }
 
 function DetailHeaderSection({
-  group, currentTime, children,
+  group, children,
 }: PropsWithChildren<Props>): ReactElement {
   const { writer, views } = group;
 
+  const currentTime = useCurrentTime(group);
   const recruitDate = useRecruitDateStatus(group, currentTime);
 
   return (

--- a/src/components/detail/DetailStatusButton.tsx
+++ b/src/components/detail/DetailStatusButton.tsx
@@ -2,8 +2,10 @@ import React, { ReactElement } from 'react';
 
 import * as R from 'ramda';
 
+import useCurrentTime from '@/hooks/useCurrentTime';
 import { Profile } from '@/models/auth';
 import { Applicant, ApplicantForm, Group } from '@/models/group';
+import { isRecruiting } from '@/utils/utils';
 
 import ApplicantStatusButton from './ApplicantStatusButton';
 import WriterStatusButtons from './WriterStatusButtons';
@@ -22,6 +24,7 @@ function DetailStatusButton({
 }: Props): ReactElement {
   const { writer, isCompleted } = group;
 
+  const currentTime = useCurrentTime(group);
   const isWriter = R.equals(writer.uid, user?.uid);
   const findApplicant = applicants.find(({ applicant }) => applicant.uid === user?.uid);
 
@@ -37,6 +40,7 @@ function DetailStatusButton({
       onApply={onApply}
       isCompleted={isCompleted}
       applicant={findApplicant}
+      isRecruiting={isRecruiting(group, currentTime)}
       onCancelApply={onCancelApply}
       onVisibleSignInModal={onVisibleSignInModal}
     />

--- a/src/components/home/RecruitPost.tsx
+++ b/src/components/home/RecruitPost.tsx
@@ -21,9 +21,9 @@ interface Props {
 
 function RecruitPost({ group }: Props): ReactElement {
   const {
-    title, content, groupId, writer, isCompleted,
+    title, content, groupId, writer,
   } = group;
-  const currentTime = useCurrentTime(isCompleted);
+  const currentTime = useCurrentTime(group);
   const recruitDate = useRecruitDateStatus(group, currentTime);
 
   return (

--- a/src/containers/detail/DetailHeaderContainer.tsx
+++ b/src/containers/detail/DetailHeaderContainer.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 
 import DetailHeaderSection from '@/components/detail/DetailHeaderSection';
 import DetailStatusButton from '@/components/detail/DetailStatusButton';
-import useCurrentTime from '@/hooks/useCurrentTime';
 import { ApplicantForm, Group } from '@/models/group';
 import { setSignInModalVisible } from '@/reducers/authSlice';
 import { loadApplicants, requestAddApplicant, requestDeleteApplicant } from '@/reducers/groupSlice';
@@ -15,7 +14,6 @@ function DetailHeaderContainer(): ReactElement {
   const group = useSelector(getGroup('group')) as Group;
   const user = useSelector(getAuth('user'));
   const applicants = useSelector(getGroup('applicants'));
-  const currentTime = useCurrentTime(group.isCompleted);
 
   const onVisibleSignInModal = useCallback(() => dispatch(setSignInModalVisible(true)), [dispatch]);
   const onCancelApply = useCallback((applicantId: string) => {
@@ -30,10 +28,7 @@ function DetailHeaderContainer(): ReactElement {
   useEffect(() => dispatch(loadApplicants(group.groupId)), []);
 
   return (
-    <DetailHeaderSection
-      group={group}
-      currentTime={currentTime}
-    >
+    <DetailHeaderSection group={group}>
       <DetailStatusButton
         user={user}
         group={group}

--- a/src/hooks/useCurrentTime.test.ts
+++ b/src/hooks/useCurrentTime.test.ts
@@ -1,6 +1,10 @@
 import { act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 
+import { tomorrow, yesterday } from '@/utils/utils';
+
+import GROUP_FIXTURE from '../../fixtures/group';
+
 import useCurrentTime from './useCurrentTime';
 
 describe('useCurrentTime', () => {
@@ -8,16 +12,16 @@ describe('useCurrentTime', () => {
     jest.useFakeTimers();
   });
 
-  const useCurrentTimeHook = () => renderHook(() => useCurrentTime(given.isCompleted));
+  const useCurrentTimeHook = () => renderHook(() => useCurrentTime(given.group));
 
   afterEach(() => {
     jest.clearAllTimers();
   });
 
-  context('isCompleted가 true인 경우', () => {
-    given('isCompleted', () => true);
+  context('"isRecruitCompletedAndManual" 반환값이 true인 경우', () => {
+    given('group', () => (GROUP_FIXTURE));
 
-    it('실시간 시간이 반환되어야 한다', async () => {
+    it('딜레이가 없는 시간이 반환되어야 한다', async () => {
       const { result: { current } } = useCurrentTimeHook();
 
       const now = Date.now();
@@ -30,19 +34,47 @@ describe('useCurrentTime', () => {
     });
   });
 
-  context('isCompleted가 false인 경우', () => {
-    given('isCompleted', () => false);
+  context('isRecruitCompletedAndManual"이 false인 경우', () => {
+    context('현재 시간이 마감 시간 이전일 경우', () => {
+      given('group', () => ({
+        ...GROUP_FIXTURE,
+        isCompleted: false,
+        recruitmentEndSetting: 'automatic',
+        recruitmentEndDate: tomorrow(new Date()),
+      }));
 
-    it('실시간 시간이 반환되어야 한다', async () => {
-      const { result: { current } } = useCurrentTimeHook();
+      it('실시간 시간이 반환되어야 한다', async () => {
+        const { result: { current } } = useCurrentTimeHook();
 
-      const now = Date.now();
+        const now = Date.now();
 
-      await act(async () => {
-        jest.advanceTimersByTime(1000);
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        expect((current / 100).toFixed(0)).toBe((now / 100).toFixed(0));
       });
+    });
 
-      expect((current / 100).toFixed(0)).toBe((now / 100).toFixed(0));
+    context('현재 시간이 마감 시간 이후일 경우', () => {
+      given('group', () => ({
+        ...GROUP_FIXTURE,
+        isCompleted: false,
+        recruitmentEndSetting: 'automatic',
+        recruitmentEndDate: yesterday(new Date()),
+      }));
+
+      it('딜레이가 없는 시간이 반환되어야 한다', async () => {
+        const { result: { current } } = useCurrentTimeHook();
+
+        const now = Date.now();
+
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        expect((current / 100).toFixed(0)).toBe((now / 100).toFixed(0));
+      });
     });
   });
 });

--- a/src/hooks/useCurrentTime.ts
+++ b/src/hooks/useCurrentTime.ts
@@ -1,9 +1,27 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useInterval } from 'react-use';
 
-const useCurrentTime = (isCompleted: boolean) => {
+import dayjs from 'dayjs';
+
+import { Group } from '@/models/group';
+import { isRecruitCompletedAndManual } from '@/utils/utils';
+
+const useCurrentTime = (group: Group) => {
   const [currentTime, setCurrentTime] = useState<number>(Date.now());
-  const delay = isCompleted ? null : 1000;
+
+  const delay = useMemo(() => {
+    if (isRecruitCompletedAndManual(group)) {
+      return null;
+    }
+
+    const isCurrentTimeBeforeEndDate = dayjs(group.recruitmentEndDate).diff(currentTime) >= 0;
+
+    if (isCurrentTimeBeforeEndDate) {
+      return 1000;
+    }
+
+    return null;
+  }, [group, currentTime]);
 
   useInterval(() => setCurrentTime(Date.now()), delay);
 

--- a/src/hooks/useRecruitDateStatus.test.ts
+++ b/src/hooks/useRecruitDateStatus.test.ts
@@ -12,7 +12,7 @@ describe('useRecruitDateStatus', () => {
     Date.now(),
   ));
 
-  context('모집 종료를 수동으로 하는 경우', () => {
+  context('모집 종료를 수동이거나 모집 완료된 경우', () => {
     given('group', () => GROUP_FIXTURE);
 
     it('글을 작성한 날짜가 반환되어야만 한다', () => {
@@ -44,10 +44,10 @@ describe('useRecruitDateStatus', () => {
         recruitmentEndDate: yesterday(new Date()),
       }));
 
-      it('"모집 마감"이 나타나야만 한다', () => {
+      it('글을 작성한 날짜가 반환되어야만 한다', () => {
         const { result: { current } } = useRecruitDateStatusHook();
 
-        expect(current).toBe('모집 마감');
+        expect(current).toBe('2021년 10월 11일');
       });
     });
   });

--- a/src/hooks/useRecruitDateStatus.ts
+++ b/src/hooks/useRecruitDateStatus.ts
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 import { Group } from '@/models/group';
+import { isRecruitCompletedAndManual } from '@/utils/utils';
 
 import 'dayjs/locale/ko';
 
@@ -11,25 +12,25 @@ dayjs.locale('ko');
 dayjs.extend(relativeTime);
 
 const useRecruitDateStatus = (group: Group, time: number) => {
-  const { recruitmentEndDate, recruitmentEndSetting, createdAt } = group;
+  const { recruitmentEndDate, createdAt } = group;
   const createdDate = dayjs(createdAt).format('YYYY년 MM월 DD일');
   const [recruitDateStatus, setRecruitDateStatus] = useState<string>(createdDate);
 
   useEffect(() => {
-    if (!recruitmentEndDate && recruitmentEndSetting === 'manual') {
+    if (isRecruitCompletedAndManual(group)) {
       setRecruitDateStatus(createdDate);
       return;
     }
 
-    const isEndDateBeforeCurrentTime = dayjs(recruitmentEndDate).diff(time) >= 0;
+    const isCurrentTimeBeforeEndDate = dayjs(recruitmentEndDate).diff(time) >= 0;
 
-    if (isEndDateBeforeCurrentTime) {
+    if (isCurrentTimeBeforeEndDate) {
       setRecruitDateStatus(`${dayjs(time).to(dayjs(recruitmentEndDate))} 마감`);
       return;
     }
 
-    setRecruitDateStatus('모집 마감');
-  }, [recruitmentEndDate, recruitmentEndSetting, createdDate, time]);
+    setRecruitDateStatus(createdDate);
+  }, [group, createdDate, time]);
 
   return recruitDateStatus;
 };

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,10 +1,18 @@
 import { RootReducerState } from '@/reducers/rootReducer';
 
+import GROUP_FIXTURE from '../../fixtures/group';
 import WRITE_FIELDS_FIXTURE from '../../fixtures/writeFields';
 
 import {
   emptyAThenB,
-  getAuth, getGroup, isProdLevel, stringToExcludeNull, tomorrow, yesterday,
+  getAuth,
+  getGroup,
+  isProdLevel,
+  isRecruitCompletedAndManual,
+  isRecruiting,
+  stringToExcludeNull,
+  tomorrow,
+  yesterday,
 } from './utils';
 
 describe('isProdLevel', () => {
@@ -146,5 +154,73 @@ describe('yesterday', () => {
     now.setDate(now.getDate() - 1);
 
     expect(result).toBe(now.toString());
+  });
+});
+
+describe('isRecruiting', () => {
+  context('"recruitmentEndSetting"는 "manual"이고 "recruitmentEndDate"는 존재하지 않을 경우', () => {
+    it('true를 반환해야만 한다', () => {
+      const result = isRecruiting(GROUP_FIXTURE, Date.now());
+
+      expect(result).toBeTruthy();
+    });
+  });
+
+  context('"recruitmentEndSetting"는 "automatic"이고 현재 시간보다 이전 시간일 경우', () => {
+    it('false를 반환해야만 한다', () => {
+      const result = isRecruiting({
+        ...GROUP_FIXTURE,
+        recruitmentEndDate: '2021-11-11',
+        recruitmentEndSetting: 'automatic',
+      }, Date.now());
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  context('"recruitmentEndSetting"는 "automatic"이고 현재 시간보다 이후 시간일 경우', () => {
+    it('true를 반환해야만 한다', () => {
+      const result = isRecruiting({
+        ...GROUP_FIXTURE,
+        recruitmentEndDate: tomorrow(new Date()),
+        recruitmentEndSetting: 'automatic',
+      }, Date.now());
+
+      expect(result).toBeTruthy();
+    });
+  });
+});
+
+describe('isRecruitCompletedAndManual', () => {
+  context('"isCompleted"가 true인 경우', () => {
+    it('true를 반환해야만 한다', () => {
+      const result = isRecruitCompletedAndManual({
+        ...GROUP_FIXTURE,
+        isCompleted: true,
+      });
+
+      expect(result).toBeTruthy();
+    });
+  });
+
+  context('"recruitmentEndSetting"는 "manual"이고 "recruitmentEndDate"는 존재하지 않을 경우', () => {
+    it('true를 반환해야만 한다', () => {
+      const result = isRecruitCompletedAndManual(GROUP_FIXTURE);
+
+      expect(result).toBeTruthy();
+    });
+  });
+
+  context('"recruitmentEndSetting"는 "automatic"이고 "isCompleted"가 false인 경우', () => {
+    it('false를 반환해야만 한다', () => {
+      const result = isRecruitCompletedAndManual({
+        ...GROUP_FIXTURE,
+        isCompleted: false,
+        recruitmentEndDate: tomorrow(new Date()),
+        recruitmentEndSetting: 'automatic',
+      });
+
+      expect(result).toBeFalsy();
+    });
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+
+import { Group } from '@/models/group';
 import type { AuthStore } from '@/reducers/authSlice';
 import type { GroupStore } from '@/reducers/groupSlice';
 import type { AppState } from '@/reducers/store';
@@ -31,8 +34,25 @@ export const tomorrow = (date: Date) => {
 
   return date.toString();
 };
+
 export const yesterday = (date: Date) => {
   date.setDate(date.getDate() - 1);
 
   return date.toString();
+};
+
+export const isRecruiting = (group: Group, time: number) => {
+  const { recruitmentEndDate, recruitmentEndSetting } = group;
+
+  if (!recruitmentEndDate && recruitmentEndSetting === 'manual') {
+    return true;
+  }
+
+  return dayjs(recruitmentEndDate).diff(time) >= 0;
+};
+
+export const isRecruitCompletedAndManual = (group: Group) => {
+  const { recruitmentEndDate, recruitmentEndSetting, isCompleted } = group;
+
+  return isCompleted || (!recruitmentEndDate && recruitmentEndSetting === 'manual');
 };


### PR DESCRIPTION
- 자동으로 시간초가 변경되는 로직은 모집중일때만
- 모집 마감 및 모집 완료 상태일 때는 detail 페이지에서 글 작성 일자가 나타나고, 모집 중일 때만 ~ 후 모집마감 문구가 나타난다.
- 모집 마감일 경우 신청 및 신청 취소 버튼이 사용자에게 안보여야한다.