### PR TITLE
[Feature] 모집 완료 플로우를 구현하라

### DIFF
--- a/src/components/applicants/ApplicationStatusHeader.test.tsx
+++ b/src/components/applicants/ApplicationStatusHeader.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Applicant } from '@/models/group';
+
+import APPLICANT_FIXTURE from '../../../fixtures/applicant';
+
+import ApplicationStatusHeader from './ApplicationStatusHeader';
+
+describe('ApplicationStatusHeader', () => {
+  const handleGoBack = jest.fn();
+  const handleSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderApplicationStatusHeader = (applicant: Applicant) => render((
+    <ApplicationStatusHeader
+      onSubmit={handleSubmit}
+      goBack={handleGoBack}
+      applicants={[applicant]}
+    />
+  ));
+
+  describe('"1명의 신청현황"을 클릭한다', () => {
+    it('goback함수가 호출되어야만 한다', () => {
+      renderApplicationStatusHeader(APPLICANT_FIXTURE);
+
+      fireEvent.click(screen.getByText('1명의 신청현황'));
+
+      expect(handleGoBack).toBeCalledTimes(1);
+    });
+  });
+
+  context('승인된 신청자가 1명 이상인 경우', () => {
+    describe('"모집완료" 버튼 클릭 후 모달창에서 "완료하기" 버튼을 클릭한다', () => {
+      it('클릭 이벤트가 호출되어야만 한다', () => {
+        renderApplicationStatusHeader({
+          ...APPLICANT_FIXTURE,
+          isConfirm: true,
+        });
+
+        fireEvent.click(screen.getByText('모집 완료'));
+        fireEvent.click(screen.getByText('완료하기'));
+
+        expect(handleSubmit).toBeCalledTimes(1);
+      });
+    });
+
+    describe('모달창에서 "닫기" 버튼을 클릭한다', () => {
+      it('모달창이 보이지 않아야만 한다', () => {
+        const { container } = renderApplicationStatusHeader({
+          ...APPLICANT_FIXTURE,
+          isConfirm: true,
+        });
+
+        fireEvent.click(screen.getByText('모집 완료'));
+        fireEvent.click(screen.getByText('닫기'));
+
+        expect(container).not.toHaveTextContent('완료하기');
+      });
+    });
+  });
+});

--- a/src/components/applicants/ApplicationStatusHeader.tsx
+++ b/src/components/applicants/ApplicationStatusHeader.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import { Applicant } from '@/models/group';
+import { body2Font } from '@/styles/fontStyles';
+
+import Button from '../common/Button';
+import SubHeader from '../common/SubHeader';
+
+import CompleteApplyFormModal from './CompleteApplyFormModal';
+
+interface Props{
+  goBack: () => void;
+  applicants: Applicant[];
+  onSubmit: () => void;
+}
+
+function ApplicationStatusHeader({ goBack, onSubmit, applicants }: Props) {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+  const numberConfirmApplicant = applicants.filter(({ isConfirm }) => isConfirm).length;
+
+  const onClose = () => setIsVisible(false);
+  const handleSubmit = () => {
+    onSubmit();
+    onClose();
+  };
+
+  return (
+    <>
+      <SubHeader
+        goBack={goBack}
+        previousText={`${applicants.length}명의 신청현황`}
+      >
+        <>
+          <SelectApplicantStatus>
+            {`${numberConfirmApplicant}명 선택`}
+          </SelectApplicantStatus>
+          <Button
+            type="button"
+            size="small"
+            color="success"
+            disabled={!numberConfirmApplicant}
+            onClick={() => setIsVisible(true)}
+          >
+            모집 완료
+          </Button>
+        </>
+      </SubHeader>
+      <CompleteApplyFormModal
+        onClose={onClose}
+        onSubmit={handleSubmit}
+        isVisible={isVisible}
+        numberApplicant={numberConfirmApplicant}
+      />
+    </>
+  );
+}
+
+export default ApplicationStatusHeader;
+
+const SelectApplicantStatus = styled.span`
+  ${body2Font()};
+  margin-right: 16px;
+`;

--- a/src/components/applicants/CompleteApplyFormModal.test.tsx
+++ b/src/components/applicants/CompleteApplyFormModal.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+
+import CompleteApplyFormModal from './CompleteApplyFormModal';
+
+describe('CompleteApplyFormModal', () => {
+  const handleClose = jest.fn();
+  const handleSubmit = jest.fn();
+
+  const renderCompleteApplyFormModal = () => render((
+    <CompleteApplyFormModal
+      isVisible
+      onSubmit={handleSubmit}
+      onClose={handleClose}
+      numberApplicant={3}
+    />
+  ));
+
+  it('모달에 대한 내용이 나타나야만 한다', () => {
+    const { container } = renderCompleteApplyFormModal();
+
+    expect(container).toHaveTextContent('모집을 완료하고 선택한 3명과 함께 팀을 만드시겠습니까?');
+  });
+});

--- a/src/components/applicants/CompleteApplyFormModal.tsx
+++ b/src/components/applicants/CompleteApplyFormModal.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+
+import { body1Font, body2Font, subtitle1Font } from '@/styles/fontStyles';
+import palette from '@/styles/palette';
+
+import FormModal from '../common/FormModal';
+
+interface Props {
+  isVisible: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  numberApplicant: number;
+}
+
+function CompleteApplyFormModal({
+  numberApplicant, isVisible, onClose, onSubmit,
+}: Props) {
+  return (
+    <FormModal
+      isVisible={isVisible}
+      title="모집 완료"
+      confirmButtonColor="success"
+      confirmText="완료하기"
+      onClose={onClose}
+      onSubmit={onSubmit}
+      size="small"
+    >
+      <FormContentsWrapper>
+        <DescribeMessage>
+          {`모집을 완료하고 선택한 ${numberApplicant}명과 함께 팀을 만드시겠습니까?`}
+          <br />
+          모집을 완료하시면 다시 되돌릴 수 없습니다.
+        </DescribeMessage>
+        <MessageInputWrapper>
+          <label htmlFor="message">
+            메시지
+            <span>(선택)</span>
+          </label>
+          <MessageInput id="message" placeholder="팀 멤버들에게 보낼 메시지를 입력하세요" autoComplete="off" />
+          <small>
+            팀 멤버들과 함께 대화할 오픈 채팅방 URL을 메시지로 보내보세요.
+            <br />
+            메시지는 멤버들에게만 공개됩니다.
+          </small>
+        </MessageInputWrapper>
+      </FormContentsWrapper>
+    </FormModal>
+  );
+}
+
+export default CompleteApplyFormModal;
+
+const FormContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const DescribeMessage = styled.div`
+  ${body1Font()}
+  margin-top: 5px;
+  text-align: start;
+`;
+
+const MessageInputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 360px;
+  margin-top: 20px;
+  margin-bottom: 40px;
+
+  & > label {
+    ${body2Font(true)}
+    color: ${palette.accent6};
+    margin-left: 2px;
+    margin-bottom: 6px;
+
+    & > span {
+      ${body2Font()}
+      color: ${palette.accent4};
+    }
+  }
+
+  & > small {
+    ${subtitle1Font()}
+    color: ${palette.accent5};
+    margin-left: 2px;
+    margin-top: 6px;
+  }
+`;
+
+const MessageInput = styled.input`
+  padding: 11px 16px;
+  border: 1px solid ${palette.accent2};
+  box-sizing: border-box;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.2s ease-in-out;
+
+  &::placeholder {
+    color: ${palette.accent4};
+  }
+
+  &:focus {
+    border: 1px solid ${palette.success};
+  }
+`;

--- a/src/components/common/FormModal.test.tsx
+++ b/src/components/common/FormModal.test.tsx
@@ -9,6 +9,7 @@ describe('FormModal', () => {
 
   const renderFormModal = () => render((
     <FormModal
+      size={given.size}
       isVisible={given.isVisible}
       title="제목"
       onClose={handleClose}
@@ -20,6 +21,30 @@ describe('FormModal', () => {
 
   context('isVisible이 true인 경우', () => {
     given('isVisible', () => true);
+
+    context('size가 small인 경우', () => {
+      given('size', () => 'small');
+
+      it('width값은 400px이어야만 한다', () => {
+        renderFormModal();
+
+        expect(screen.getByTestId('form-modal-box')).toHaveStyle({
+          width: '400px',
+        });
+      });
+    });
+
+    context('size가 medium인 경우', () => {
+      given('size', () => 'medium');
+
+      it('width값은 600px이어야만 한다', () => {
+        renderFormModal();
+
+        expect(screen.getByTestId('form-modal-box')).toHaveStyle({
+          width: '600px',
+        });
+      });
+    });
 
     describe('닫기 버튼을 클릭한다', () => {
       it('클릭 이벤트가 호출되어야만 한다', () => {

--- a/src/components/common/FormModal.tsx
+++ b/src/components/common/FormModal.tsx
@@ -12,6 +12,8 @@ import zIndexes from '@/styles/zIndexes';
 import type { ColorType as ButtonColorType } from './Button';
 import Button from './Button';
 
+type FormModalSize = 'small' | 'medium';
+
 interface Props {
   isVisible: boolean;
   title: string;
@@ -19,11 +21,12 @@ interface Props {
   closeText?: string;
   onSubmit: () => void;
   onClose: () => void;
+  size?: FormModalSize;
   confirmButtonColor?: ButtonColorType;
 }
 
 function FormModal({
-  isVisible, title, confirmText = '확인', closeText = '닫기', onSubmit, onClose, confirmButtonColor = 'success', children,
+  isVisible, title, confirmText = '확인', closeText = '닫기', onSubmit, onClose, confirmButtonColor = 'success', children, size = 'medium',
 }: PropsWithChildren<Props>): ReactElement | null {
   if (!isVisible) {
     return null;
@@ -31,7 +34,7 @@ function FormModal({
 
   return (
     <FormModalWrapper>
-      <FormModalBox isVisible={isVisible}>
+      <FormModalBox size={size} isVisible={isVisible} data-testid="form-modal-box">
         <form onSubmit={onSubmit}>
           <HeaderWrapper>
             <h4>{title}</h4>
@@ -68,11 +71,18 @@ const FormModalWrapper = styled.div`
   background: rgba(0, 0, 0, 0.25);
 `;
 
-const FormModalBox = styled.div<{ isVisible: boolean }>`
-  width: 600px;
+const FormModalBox = styled.div<{ size: FormModalSize; isVisible: boolean }>`
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.09);
   background: ${palette.background};
   border-radius: 8px;
+
+  ${({ size }) => size === 'medium' && css`
+    width: 600px;
+  `};
+
+  ${({ size }) => size === 'small' && css`
+    width: 400px;
+  `};
 
   ${({ isVisible }) => (isVisible && css`
     animation: ${transitions.popInFromBottom} 0.4s forwards ease-in-out;

--- a/src/components/common/SubHeader.tsx
+++ b/src/components/common/SubHeader.tsx
@@ -65,5 +65,6 @@ const HeaderWrapper = styled(Layout)`
 
 const GoBackButton = styled.button`
   ${h4Font(true)};
-  background: none;
+  background: transparent;
+  color: ${palette.foreground};
 `;

--- a/src/containers/applicants/ApplicationStatusContainer.test.tsx
+++ b/src/containers/applicants/ApplicationStatusContainer.test.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import APPLICANT_FIXTURE from '../../../fixtures/applicant';
+import GROUP_FIXTURE from '../../../fixtures/group';
 
 import ApplicationStatusContainer from './ApplicationStatusContainer';
 
@@ -16,7 +17,7 @@ describe('ApplicationStatusContainer', () => {
     (useSelector as jest.Mock).mockImplementation((selector) => selector({
       groupReducer: {
         applicants: [APPLICANT_FIXTURE],
-        groupId: '1',
+        group: GROUP_FIXTURE,
       },
     }));
   });

--- a/src/containers/applicants/ApplicationStatusContainer.tsx
+++ b/src/containers/applicants/ApplicationStatusContainer.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import ApplicationStatus from '@/components/applicants/ApplicationStatus';
-import { Applicant } from '@/models/group';
+import { Applicant, Group } from '@/models/group';
 import { loadApplicants, updateApplicant } from '@/reducers/groupSlice';
 import { useAppDispatch } from '@/reducers/store';
 import { DetailLayout } from '@/styles/Layout';
@@ -11,7 +11,7 @@ import { getGroup } from '@/utils/utils';
 function ApplicationStatusContainer(): ReactElement {
   const dispatch = useAppDispatch();
   const applicants = useSelector(getGroup('applicants'));
-  const groupId = useSelector(getGroup('groupId')) as string;
+  const group = useSelector(getGroup('group')) as Group;
 
   const onToggleConfirm = useCallback((applicant: Applicant) => dispatch(updateApplicant({
     ...applicant,
@@ -19,7 +19,7 @@ function ApplicationStatusContainer(): ReactElement {
   })), [dispatch]);
 
   useEffect(() => {
-    dispatch(loadApplicants(groupId));
+    dispatch(loadApplicants(group.groupId));
   }, []);
 
   return (

--- a/src/containers/applicants/ApplicationStatusHeaderContainer.test.tsx
+++ b/src/containers/applicants/ApplicationStatusHeaderContainer.test.tsx
@@ -1,9 +1,10 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useRouter } from 'next/router';
 
 import APPLICANT_FIXTURE from '../../../fixtures/applicant';
+import GROUP_FIXTURE from '../../../fixtures/group';
 
 import ApplicationStatusHeaderContainer from './ApplicationStatusHeaderContainer';
 
@@ -13,18 +14,27 @@ jest.mock('next/router', () => ({
 
 describe('ApplicationStatusHeaderContainer', () => {
   const handleBack = jest.fn();
+  const handleReplace = jest.fn();
+  const dispatch = jest.fn();
 
   beforeEach(() => {
-    handleBack.mockClear();
+    jest.clearAllMocks();
+
+    (useDispatch as jest.Mock).mockImplementation(() => dispatch);
 
     (useSelector as jest.Mock).mockImplementation((selector) => selector({
       groupReducer: {
-        applicants: [APPLICANT_FIXTURE],
+        group: given.group,
+        applicants: [{
+          ...APPLICANT_FIXTURE,
+          isConfirm: true,
+        }],
       },
     }));
 
     (useRouter as jest.Mock).mockImplementation(() => ({
       back: handleBack,
+      replace: handleReplace,
     }));
   });
 
@@ -32,13 +42,41 @@ describe('ApplicationStatusHeaderContainer', () => {
     <ApplicationStatusHeaderContainer />
   ));
 
-  describe('"1명의 신청현황"을 클릭한다', () => {
-    it('router.back이 호출되어야만 한다', () => {
+  context('모집완료가 되지 않은 글인 경우', () => {
+    given('group', () => GROUP_FIXTURE);
+
+    describe('"1명의 신청현황"을 클릭한다', () => {
+      it('router.back이 호출되어야만 한다', () => {
+        renderApplicationStatusHeaderContainer();
+
+        fireEvent.click(screen.getByText('1명의 신청현황'));
+
+        expect(handleBack).toBeCalledTimes(1);
+      });
+    });
+
+    describe('"모집완료" 버튼 클릭 후 모달창에서 "완료하기" 버튼을 클릭한다', () => {
+      it('dispatch 액션이 호출되어야만 한다', () => {
+        renderApplicationStatusHeaderContainer();
+
+        fireEvent.click(screen.getByText('모집 완료'));
+        fireEvent.click(screen.getByText('완료하기'));
+
+        expect(dispatch).toBeCalledTimes(1);
+      });
+    });
+  });
+
+  context('모집완료된 글인 경우', () => {
+    given('group', () => ({
+      ...GROUP_FIXTURE,
+      isCompleted: true,
+    }));
+
+    it('router.replace가 호출되어야만 한다', () => {
       renderApplicationStatusHeaderContainer();
 
-      fireEvent.click(screen.getByText('1명의 신청현황'));
-
-      expect(handleBack).toBeCalledTimes(1);
+      expect(handleReplace).toBeCalledTimes(1);
     });
   });
 });

--- a/src/containers/applicants/ApplicationStatusHeaderContainer.tsx
+++ b/src/containers/applicants/ApplicationStatusHeaderContainer.tsx
@@ -1,39 +1,37 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 
-import Button from '@/components/common/Button';
-import SubHeader from '@/components/common/SubHeader';
-import { body2Font } from '@/styles/fontStyles';
+import ApplicationStatusHeader from '@/components/applicants/ApplicationStatusHeader';
+import { Group } from '@/models/group';
+import { updateCompletedApply } from '@/reducers/groupSlice';
+import { useAppDispatch } from '@/reducers/store';
 import { getGroup } from '@/utils/utils';
 
 function ApplicationStatusHeaderContainer(): ReactElement {
-  const router = useRouter();
+  const { back, replace } = useRouter();
+  const dispatch = useAppDispatch();
   const applicants = useSelector(getGroup('applicants'));
-  const numberConfirmApplicant = applicants.filter(({ isConfirm }) => isConfirm).length;
+  const group = useSelector(getGroup('group')) as Group;
+
+  const onSubmit = useCallback(() => dispatch(updateCompletedApply(group)), [dispatch]);
+
+  useEffect(() => {
+    const { isCompleted, groupId } = group;
+
+    if (isCompleted) {
+      replace(`/detail/${groupId}`);
+    }
+  }, [group]);
 
   return (
-    <SubHeader
-      goBack={() => router.back()}
-      previousText={`${applicants.length}명의 신청현황`}
-    >
-      <>
-        <SelectApplicantStatus>
-          {`${numberConfirmApplicant}명 선택`}
-        </SelectApplicantStatus>
-        <Button type="button" size="small" color="success" disabled={!numberConfirmApplicant}>
-          모집 완료
-        </Button>
-      </>
-    </SubHeader>
+    <ApplicationStatusHeader
+      goBack={back}
+      onSubmit={onSubmit}
+      applicants={applicants}
+    />
   );
 }
 
 export default ApplicationStatusHeaderContainer;
-
-const SelectApplicantStatus = styled.span`
-  ${body2Font()};
-  margin-right: 16px;
-`;

--- a/src/pages/detail/[id]/applicants.page.tsx
+++ b/src/pages/detail/[id]/applicants.page.tsx
@@ -7,7 +7,7 @@ import nookies from 'nookies';
 
 import ApplicationStatusContainer from '@/containers/applicants/ApplicationStatusContainer';
 import ApplicationStatusHeaderContainer from '@/containers/applicants/ApplicationStatusHeaderContainer';
-import { setGroupId } from '@/reducers/groupSlice';
+import { setGroup } from '@/reducers/groupSlice';
 import wrapper from '@/reducers/store';
 import { getGroupDetail } from '@/services/api/group';
 import firebaseAdmin from '@/services/firebase/firebaseAdmin';
@@ -23,12 +23,21 @@ export const getServerSideProps: GetServerSideProps = wrapper
     try {
       const cookies = nookies.get(context);
       const token = await firebaseAdmin.auth().verifyIdToken(cookies.token);
-
       const group = await getGroupDetail(id);
 
       if (!group) {
         return {
           notFound: true,
+        };
+      }
+
+      if (group.isCompleted) {
+        return {
+          redirect: {
+            permanent: false,
+            destination: '/?error=unauthenticated',
+          },
+          props: {},
         };
       }
 
@@ -44,7 +53,7 @@ export const getServerSideProps: GetServerSideProps = wrapper
         };
       }
 
-      dispatch(setGroupId(group.groupId));
+      dispatch(setGroup(group));
 
       return {
         props: {},

--- a/src/reducers/groupSlice.test.ts
+++ b/src/reducers/groupSlice.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@/services/api/applicants';
 import { deleteGroupComment, getGroupComments, postGroupComment } from '@/services/api/comment';
 import {
-  getGroupDetail, getGroups, postNewGroup,
+  getGroupDetail, getGroups, patchCompletedGroup, postNewGroup,
 } from '@/services/api/group';
 import { getTagsCount, updateTagCount } from '@/services/api/tagsCount';
 import { formatApplicant, formatComment, formatGroup } from '@/utils/firestore';
@@ -44,6 +44,7 @@ import reducer, {
   setPublishModalVisible,
   setTagsCount,
   updateApplicant,
+  updateCompletedApply,
 } from './groupSlice';
 
 const middlewares = [thunk];
@@ -730,6 +731,51 @@ describe('groupReducer async actions', () => {
       it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
         try {
           await store.dispatch(updateApplicant(APPLICANT_FIXTURE));
+        } catch (error) {
+          // ignore errors
+        } finally {
+          const actions = store.getActions();
+
+          expect(actions[0]).toEqual({
+            payload: 'error',
+            type: 'group/setGroupError',
+          });
+        }
+      });
+    });
+  });
+
+  describe('updateCompletedApply', () => {
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    context('에러가 발생하지 않는 경우', () => {
+      (patchCompletedGroup as jest.Mock).mockReturnValueOnce(null);
+
+      it('dispatch 액션이 "group/setGroup"인 타입과 payload는 group여야 한다', async () => {
+        await store.dispatch(updateCompletedApply(GROUP_FIXTURE));
+
+        const actions = store.getActions();
+
+        expect(actions[0]).toEqual({
+          payload: {
+            ...GROUP_FIXTURE,
+            isCompleted: true,
+          },
+          type: 'group/setGroup',
+        });
+      });
+    });
+
+    context('에러가 발생하는 경우', () => {
+      (patchCompletedGroup as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('error');
+      });
+
+      it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
+        try {
+          await store.dispatch(updateCompletedApply(GROUP_FIXTURE));
         } catch (error) {
           // ignore errors
         } finally {

--- a/src/reducers/groupSlice.ts
+++ b/src/reducers/groupSlice.ts
@@ -14,7 +14,7 @@ import {
 } from '@/services/api/applicants';
 import { deleteGroupComment, getGroupComments, postGroupComment } from '@/services/api/comment';
 import {
-  getGroupDetail, getGroups, postNewGroup,
+  getGroupDetail, getGroups, patchCompletedGroup, postNewGroup,
 } from '@/services/api/group';
 import { getTagsCount, updateTagCount } from '@/services/api/tagsCount';
 import { formatApplicant, formatComment, formatGroup } from '@/utils/firestore';
@@ -349,6 +349,21 @@ export const updateApplicant = (
     });
 
     dispatch(setApplicants(newApplicants));
+  } catch (error) {
+    const { message } = error as Error;
+
+    dispatch(setGroupError(message));
+  }
+};
+
+export const updateCompletedApply = (group: Group): AppThunk => async (dispatch) => {
+  try {
+    await patchCompletedGroup(group.groupId);
+
+    dispatch(setGroup({
+      ...group,
+      isCompleted: true,
+    }));
   } catch (error) {
     const { message } = error as Error;
 

--- a/src/services/api/__mocks__/group.ts
+++ b/src/services/api/__mocks__/group.ts
@@ -3,3 +3,5 @@ export const postNewGroup = jest.fn();
 export const getGroupDetail = jest.fn();
 
 export const getGroups = jest.fn();
+
+export const patchCompletedGroup = jest.fn();

--- a/src/services/api/group.test.ts
+++ b/src/services/api/group.test.ts
@@ -1,10 +1,10 @@
 import {
-  addDoc, getDoc, getDocs, serverTimestamp,
+  addDoc, getDoc, getDocs, serverTimestamp, updateDoc,
 } from 'firebase/firestore';
 
 import { WriteFields } from '@/models/group';
 import {
-  getGroupDetail, getGroups, postNewGroup,
+  getGroupDetail, getGroups, patchCompletedGroup, postNewGroup,
 } from '@/services/api/group';
 
 import GROUP_FIXTURE from '../../../fixtures/group';
@@ -100,6 +100,14 @@ describe('group API', () => {
       const response = await getGroups([]);
 
       expect(response).toEqual([GROUP_FIXTURE]);
+    });
+  });
+
+  describe('patchCompletedGroup', () => {
+    it('"updateDoc"이 호출되어야만 한다', async () => {
+      await patchCompletedGroup('groupId');
+
+      expect(updateDoc).toBeCalledTimes(1);
     });
   });
 });

--- a/src/services/api/group.ts
+++ b/src/services/api/group.ts
@@ -1,5 +1,5 @@
 import {
-  addDoc, getDoc, getDocs, orderBy, query, serverTimestamp, where,
+  addDoc, getDoc, getDocs, orderBy, query, serverTimestamp, updateDoc, where,
 } from 'firebase/firestore';
 
 import { Profile } from '@/models/auth';
@@ -24,8 +24,8 @@ export const postNewGroup = async (profile: Profile, fields: WriteFields) => {
   return id;
 };
 
-export const getGroupDetail = async (id: string) => {
-  const response = await getDoc(docRef(GROUPS, id));
+export const getGroupDetail = async (uid: string) => {
+  const response = await getDoc(docRef(GROUPS, uid));
 
   if (!response.exists()) {
     return null;
@@ -50,4 +50,10 @@ export const getGroups = async (condition: Category[]) => {
   const response = await getDocs(getQuery);
 
   return response.docs;
+};
+
+export const patchCompletedGroup = async (uid: string) => {
+  await updateDoc(docRef(GROUPS, uid), {
+    isCompleted: true,
+  });
 };


### PR DESCRIPTION
1. 작성자는 신청현황 페이지에서 1명 이상의 신청자를 선택 후 모집 완료 버튼을 클릭한다.
2. 모집 완료 모달창이 나타나고 완료하기 버튼을 클릭하면 해당 글 페이지로 redirect되면서 모집을 완료할 수 있다.
3. 팀원 보기 버튼이 나와야 한다.
![스크린샷 2022-01-21 오전 3 07 34](https://user-images.githubusercontent.com/60910665/150396710-45df8c9a-fdfc-483e-b8be-5167ebd7262e.png)

