### PR TITLE
[Feature] 로그인한 사용자는 내 정보 페이지를 볼 수 있게하라

### DIFF
--- a/src/components/common/DropDown.tsx
+++ b/src/components/common/DropDown.tsx
@@ -1,6 +1,8 @@
 import React, { ReactElement } from 'react';
 
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import Link from 'next/link';
 
 import { body1Font, subtitle1Font } from '@/styles/fontStyles';
 
@@ -27,9 +29,9 @@ function DropDown({
           <div className="user-name">{name}</div>
           <div className="user-email">{email}</div>
         </UserState>
-        <MenuContent>
-          내 정보
-        </MenuContent>
+        <Link href="/myinfo/setting" passHref>
+          <MyInfoMenu>내 정보</MyInfoMenu>
+        </Link>
         <Pipe />
         <MenuContent
           className="logout-menu"
@@ -81,18 +83,27 @@ const UserState = styled.div`
   }
 `;
 
-const MenuContent = styled.div`
+const navItem = css`
   ${body1Font()};
   color: ${palette.foreground};
   padding: 0.6rem 1rem;
   cursor: pointer;
   transition: background-color .2s;
-  
-  &.logout-menu {
-    padding-bottom: 0.875rem;
-  }
 
   &:hover {
     background: ${palette.accent1};
   }
+`;
+
+const MenuContent = styled.div`
+  ${navItem}
+  
+  &.logout-menu {
+    padding-bottom: 0.875rem;
+  }
+`;
+
+const MyInfoMenu = styled.a`
+  ${navItem}
+  display: block;
 `;

--- a/src/components/common/UserNavbar.tsx
+++ b/src/components/common/UserNavbar.tsx
@@ -76,7 +76,7 @@ const UserNavbarWrapper = styled.div`
   display: flex;
   flex-direction: row;
 
-  & a:first-of-type {
+  & > a:first-of-type {
     margin-right: 24px;
   }
 

--- a/src/components/myInfo/MyInfoLayout.test.tsx
+++ b/src/components/myInfo/MyInfoLayout.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+
+import getMyInfoLayout from './MyInfoLayout';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockImplementation(() => ({
+    pathname: '/',
+  })),
+}));
+
+describe('MyInfoLayout', () => {
+  const GetLayout = getMyInfoLayout('setting');
+  function MockComponent(): JSX.Element {
+    return <>Test</>;
+  }
+
+  const renderMyInfoLayout = () => render((
+    GetLayout(<MockComponent />)
+  ));
+
+  it('MyInfo 레이아웃에 대한 내용이 보여야만 한다', () => {
+    const { container } = renderMyInfoLayout();
+
+    expect(container).toHaveTextContent('Test');
+  });
+});

--- a/src/components/myInfo/MyInfoLayout.tsx
+++ b/src/components/myInfo/MyInfoLayout.tsx
@@ -1,0 +1,17 @@
+import { ReactElement } from 'react';
+
+import HeaderContainer from '@/containers/common/HeaderContainer';
+
+import MyInfoTab, { MyInfoNavActive } from './MyInfoTab';
+
+const getMyInfoLayout = (active: MyInfoNavActive) => function GetLayout(page: ReactElement) {
+  return (
+    <>
+      <HeaderContainer />
+      <MyInfoTab active={active} />
+      {page}
+    </>
+  );
+};
+
+export default getMyInfoLayout;

--- a/src/components/myInfo/MyInfoTab.test.tsx
+++ b/src/components/myInfo/MyInfoTab.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+
+import palette from '@/styles/palette';
+
+import MyInfoTab from './MyInfoTab';
+
+describe('MyInfoTab', () => {
+  const renderMyInfoTab = () => render((
+    <MyInfoTab active="setting" />
+  ));
+
+  context('active 상태인 경우', () => {
+    it(`링크의 border color가 ${palette.success10} 이어야만 한다`, () => {
+      renderMyInfoTab();
+
+      expect(screen.getByText('내 정보 수정')).toHaveStyle({
+        'border-bottom': `2px solid ${palette.success10}`,
+      });
+    });
+  });
+
+  context('active 상태가 아닌 경우', () => {
+    it('링크의 border color가 "transparent" 이어야만 한다', () => {
+      renderMyInfoTab();
+
+      expect(screen.getByText('모집한 팀')).toHaveStyle({
+        'border-bottom': '2px solid transparent',
+      });
+    });
+  });
+});

--- a/src/components/myInfo/MyInfoTab.tsx
+++ b/src/components/myInfo/MyInfoTab.tsx
@@ -1,0 +1,35 @@
+import { ReactElement } from 'react';
+
+import styled from '@emotion/styled';
+import Link from 'next/link';
+
+import palette from '@/styles/palette';
+
+export type MyInfoNavActive = 'setting' | 'recruited' | 'applied';
+
+interface Props {
+  active: MyInfoNavActive;
+}
+
+function MyInfoTab({ active }: Props): ReactElement {
+  return (
+    <nav>
+      <Link href="/myinfo/setting" passHref>
+        <StyledLink pathName="setting" active={active}>내 정보 수정</StyledLink>
+      </Link>
+      <Link href="/myinfo/recruited" passHref>
+        <StyledLink pathName="recruited" active={active}>모집한 팀</StyledLink>
+      </Link>
+      <Link href="/myinfo/applied" passHref>
+        <StyledLink pathName="applied" active={active}>신청한 팀</StyledLink>
+      </Link>
+    </nav>
+  );
+}
+
+export default MyInfoTab;
+
+const StyledLink = styled.a<{ pathName: MyInfoNavActive; active: MyInfoNavActive; }>`
+  border-bottom: 2px solid ${({ pathName, active }) => (pathName === active ? palette.success10 : 'transparent')};
+  transition: border-color .2s ease-in-out;
+`;

--- a/src/containers/detail/CommentsContainer.tsx
+++ b/src/containers/detail/CommentsContainer.tsx
@@ -1,12 +1,15 @@
 import React, { ReactElement, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { useUnmount } from 'react-use';
 
 import CommentForm from '@/components/detail/CommentForm';
 import CommentsView from '@/components/detail/CommentsView';
 import { Profile } from '@/models/auth';
 import { Group } from '@/models/group';
 import { setSignInModalVisible } from '@/reducers/authSlice';
-import { loadComments, requestAddComment, requestDeleteComment } from '@/reducers/groupSlice';
+import {
+  loadComments, requestAddComment, requestDeleteComment, setComments,
+} from '@/reducers/groupSlice';
 import { useAppDispatch } from '@/reducers/store';
 import { getAuth, getGroup } from '@/utils/utils';
 
@@ -27,6 +30,8 @@ function CommentsContainer(): ReactElement {
   }, [dispatch]);
 
   useEffect(() => dispatch(loadComments(group.groupId)), []);
+
+  useUnmount(() => dispatch(setComments([])));
 
   return (
     <>

--- a/src/containers/detail/DetailHeaderContainer.tsx
+++ b/src/containers/detail/DetailHeaderContainer.tsx
@@ -1,11 +1,14 @@
 import React, { ReactElement, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { useUnmount } from 'react-use';
 
 import DetailHeaderSection from '@/components/detail/DetailHeaderSection';
 import DetailStatusButton from '@/components/detail/DetailStatusButton';
 import { ApplicantForm, Group } from '@/models/group';
 import { setSignInModalVisible } from '@/reducers/authSlice';
-import { loadApplicants, requestAddApplicant, requestDeleteApplicant } from '@/reducers/groupSlice';
+import {
+  loadApplicants, requestAddApplicant, requestDeleteApplicant, setApplicants,
+} from '@/reducers/groupSlice';
 import { useAppDispatch } from '@/reducers/store';
 import { getAuth, getGroup } from '@/utils/utils';
 
@@ -26,6 +29,8 @@ function DetailHeaderContainer(): ReactElement {
   })), [dispatch, group.groupId]);
 
   useEffect(() => dispatch(loadApplicants(group.groupId)), []);
+
+  useUnmount(() => dispatch(setApplicants([])));
 
   return (
     <DetailHeaderSection group={group} numberApplicants={applicants.length}>

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,4 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
+import type { ReactElement, ReactNode } from 'react';
+
+import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 
 import AuthProvider from '@/components/common/AuthProvider';
@@ -6,8 +9,18 @@ import Core from '@/components/common/Core';
 import SignInModalContainer from '@/containers/auth/SignInModalContainer';
 import wrapper from '@/reducers/store';
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode
+}
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout
+}
+
+function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
+  return getLayout((
     <>
       <Core />
       <AuthProvider>
@@ -15,7 +28,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <Component {...pageProps} />
       </AuthProvider>
     </>
-  );
+  ));
 }
 
 export default wrapper.withRedux(MyApp);

--- a/src/pages/myinfo/applied.page.tsx
+++ b/src/pages/myinfo/applied.page.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement } from 'react';
+
+import { GetServerSideProps } from 'next';
+
+import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
+import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
+
+export const getServerSideProps: GetServerSideProps = authenticatedServerSideProps;
+
+function AppliedPage(): ReactElement {
+  return (
+    <div>신청한 팀</div>
+  );
+}
+
+export default AppliedPage;
+
+AppliedPage.getLayout = getMyInfoLayout('applied');

--- a/src/pages/myinfo/applied.test.tsx
+++ b/src/pages/myinfo/applied.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import AppliedPage from './applied.page';
+
+describe('AppliedPage', () => {
+  const renderAppliedPage = () => render((
+    <AppliedPage />
+  ));
+
+  it('신청한 팀 페이지에 대한 내용이 보여야만 한다', () => {
+    const { container } = renderAppliedPage();
+
+    expect(container).toHaveTextContent('신청한 팀');
+  });
+});

--- a/src/pages/myinfo/recruited.page.tsx
+++ b/src/pages/myinfo/recruited.page.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement } from 'react';
+
+import { GetServerSideProps } from 'next';
+
+import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
+import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
+
+export const getServerSideProps: GetServerSideProps = authenticatedServerSideProps;
+
+function RecruitedPage(): ReactElement {
+  return (
+    <div>모집한 팀</div>
+  );
+}
+
+export default RecruitedPage;
+
+RecruitedPage.getLayout = getMyInfoLayout('recruited');

--- a/src/pages/myinfo/recruited.test.tsx
+++ b/src/pages/myinfo/recruited.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import RecruitedPage from './recruited.page';
+
+describe('RecruitedPage', () => {
+  const renderRecruitedPage = () => render((
+    <RecruitedPage />
+  ));
+
+  it('모집한 팀 페이지에 대한 내용이 보여야만 한다', () => {
+    const { container } = renderRecruitedPage();
+
+    expect(container).toHaveTextContent('모집한 팀');
+  });
+});

--- a/src/pages/myinfo/setting.page.tsx
+++ b/src/pages/myinfo/setting.page.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement } from 'react';
+
+import { GetServerSideProps } from 'next';
+
+import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
+import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
+
+export const getServerSideProps: GetServerSideProps = authenticatedServerSideProps;
+
+function SettingPage(): ReactElement {
+  return (
+    <div>내 정보 수정</div>
+  );
+}
+
+export default SettingPage;
+
+SettingPage.getLayout = getMyInfoLayout('setting');

--- a/src/pages/myinfo/setting.test.tsx
+++ b/src/pages/myinfo/setting.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import SettingPage from './setting.page';
+
+describe('SettingPage', () => {
+  const renderSettingPage = () => render((
+    <SettingPage />
+  ));
+
+  it('내 정보 수정 페이지에 대한 내용이 보여야만 한다', () => {
+    const { container } = renderSettingPage();
+
+    expect(container).toHaveTextContent('내 정보 수정');
+  });
+});

--- a/src/services/serverSideProps/authenticatedServerSideProps.test.ts
+++ b/src/services/serverSideProps/authenticatedServerSideProps.test.ts
@@ -1,0 +1,83 @@
+import { ParsedUrlQuery } from 'querystring';
+
+import { GetServerSidePropsContext } from 'next';
+
+import firebaseAdmin from '../firebase/firebaseAdmin';
+
+import authenticatedServerSideProps from './authenticatedServerSideProps';
+
+describe('authenticatedServerSideProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockContext = {
+    params: { id: 'id' } as ParsedUrlQuery,
+  };
+
+  context('token이 존재하는 경우', () => {
+    const token = {
+      uid: '1',
+    };
+
+    beforeEach(() => {
+      (firebaseAdmin.auth as jest.Mock).mockImplementation(() => ({
+        verifyIdToken: jest.fn().mockResolvedValue(token),
+      }));
+    });
+
+    it('정상적으로 props가 반환되어야만 한다', async () => {
+      const response: any = await authenticatedServerSideProps(
+        mockContext as GetServerSidePropsContext,
+      );
+
+      expect(response).toEqual({
+        props: {},
+      });
+    });
+  });
+
+  context('token이 존재하지 않는 경우', () => {
+    const token = null;
+
+    beforeEach(() => {
+      (firebaseAdmin.auth as jest.Mock).mockImplementation(() => ({
+        verifyIdToken: jest.fn().mockResolvedValue(token),
+      }));
+    });
+
+    it('redirect를 반환해야만 한다', async () => {
+      const response: any = await authenticatedServerSideProps(
+        mockContext as GetServerSidePropsContext,
+      );
+
+      expect(response).toEqual({
+        redirect: {
+          permanent: false,
+          destination: '/?error=unauthenticated',
+        },
+        props: {},
+      });
+    });
+  });
+
+  context('에러가 발생하는 경우', () => {
+    beforeEach(() => {
+      (firebaseAdmin.auth as jest.Mock).mockImplementation(() => (new Error('Error')));
+    });
+
+    it('redirect를 반환해야만 한다', async () => {
+      const response: any = await authenticatedServerSideProps(
+        mockContext as GetServerSidePropsContext,
+      );
+
+      expect(response).toEqual({
+        redirect: {
+          permanent: false,
+          destination: '/?error=unauthenticated',
+        },
+        props: {},
+      });
+    });
+  });
+});

--- a/src/services/serverSideProps/authenticatedServerSideProps.ts
+++ b/src/services/serverSideProps/authenticatedServerSideProps.ts
@@ -1,0 +1,37 @@
+import { GetServerSidePropsContext } from 'next';
+import nookies from 'nookies';
+
+import firebaseAdmin from '@/services/firebase/firebaseAdmin';
+
+const authenticatedServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  try {
+    const cookies = nookies.get(context);
+    const token = await firebaseAdmin.auth().verifyIdToken(cookies.token);
+
+    if (!token) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: '/?error=unauthenticated',
+        },
+        props: {},
+      };
+    }
+
+    return {
+      props: {},
+    };
+  } catch (error) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/?error=unauthenticated',
+      },
+      props: {},
+    };
+  }
+};
+
+export default authenticatedServerSideProps;


### PR DESCRIPTION
- 비로그인 사용자인 경우 메인 페이지로 리다이렉트
- 내 정보 수정, 모집한 팀, 신청한 팀 라우팅 (/myinfo/setting,  /myinfo/recruited, /myinfo/applied)
- 해더에 내 정보페이지 클릭시 /myinfo/setting(내 정보 수정)으로 이동
- /myinfo 페이지로 이동시 404