### PR TITLE
[Feature] 내 정보 페이지에서 내가 모집한 팀을 볼 수 있게하라

### DIFF
--- a/fixtures/initialStore.ts
+++ b/fixtures/initialStore.ts
@@ -1,4 +1,5 @@
 import { GroupStore } from '@/reducers/groupSlice';
+import { MyInfoStore } from '@/reducers/myInfoSlice';
 
 const initialStore = {
   initialState: {
@@ -26,6 +27,10 @@ const initialStore = {
       isVisible: false,
       applicants: [],
     } as GroupStore,
+    myInfoReducer: {
+      myInfoError: null,
+      recruitedGroups: [],
+    } as MyInfoStore,
   },
 };
 

--- a/src/components/myInfo/RecruitedPost.test.tsx
+++ b/src/components/myInfo/RecruitedPost.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import FIXTURE_GROUP from '../../../fixtures/group';
+
+import RecruitedPost from './RecruitedPost';
+
+describe('RecruitedPost', () => {
+  const handleClick = jest.fn();
+
+  const renderRecruitedPost = () => render((
+    <RecruitedPost
+      onClick={handleClick}
+      group={FIXTURE_GROUP}
+    />
+  ));
+
+  it('group에 대한 내용이 나타나야만 한다', () => {
+    const { container } = renderRecruitedPost();
+
+    expect(container).toHaveTextContent(FIXTURE_GROUP.title);
+  });
+
+  describe('group을 클릭한다', () => {
+    it('클릭 이벤트가 호출되어야만 한다', () => {
+      renderRecruitedPost();
+
+      fireEvent.click(screen.getByText(FIXTURE_GROUP.title));
+
+      expect(handleClick).toBeCalledWith(FIXTURE_GROUP.groupId);
+    });
+  });
+});

--- a/src/components/myInfo/RecruitedPost.tsx
+++ b/src/components/myInfo/RecruitedPost.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from 'react';
+
+import styled from '@emotion/styled';
+import dayjs from 'dayjs';
+
+import { Group } from '@/models/group';
+
+interface Props {
+  group: Group;
+  onClick: (groupId: string) => void;
+}
+
+function RecruitedPost({ group, onClick }: Props): ReactElement {
+  const {
+    title, content, createdAt, groupId,
+  } = group;
+
+  return (
+    <RecruitedPostWrapper
+      role="menuitem"
+      onClick={() => onClick(groupId)}
+      tabIndex={0}
+    >
+      <h3>{title}</h3>
+      <div>{content}</div>
+      <div>
+        <div>{dayjs(createdAt).format('YYYY년 MM월 DD일')}</div>
+      </div>
+    </RecruitedPostWrapper>
+  );
+}
+
+export default RecruitedPost;
+
+const RecruitedPostWrapper = styled.div`
+  cursor: pointer;
+`;

--- a/src/components/myInfo/RecruitedPosts.test.tsx
+++ b/src/components/myInfo/RecruitedPosts.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+
+import FIXTURE_GROUP from '../../../fixtures/group';
+
+import RecruitedPosts from './RecruitedPosts';
+
+describe('RecruitedPosts', () => {
+  const handleClick = jest.fn();
+
+  const renderRecruitedPosts = () => render((
+    <RecruitedPosts
+      onClickGroup={handleClick}
+      groups={given.groups}
+    />
+  ));
+
+  context('모집한 group이 존재하지 않는 경우', () => {
+    given('groups', () => []);
+
+    it('"모집한 팀이 없어요."문구가 보여야만 한다', () => {
+      const { container } = renderRecruitedPosts();
+
+      expect(container).toHaveTextContent('모집한 팀이 없어요.');
+    });
+  });
+
+  context('모집한 group이 존재하는 경우', () => {
+    given('groups', () => [FIXTURE_GROUP]);
+
+    it('모집한 팀에 대한 내용이 나타나야만 한다', () => {
+      const { container } = renderRecruitedPosts();
+
+      expect(container).toHaveTextContent(FIXTURE_GROUP.title);
+    });
+  });
+});

--- a/src/components/myInfo/RecruitedPosts.tsx
+++ b/src/components/myInfo/RecruitedPosts.tsx
@@ -1,0 +1,51 @@
+import React, { ReactElement } from 'react';
+
+import styled from '@emotion/styled';
+import * as R from 'ramda';
+
+import { Group } from '@/models/group';
+import { DetailLayout } from '@/styles/Layout';
+import palette from '@/styles/palette';
+
+import EmptyStateArea from '../common/EmptyStateArea';
+
+import RecruitedPost from './RecruitedPost';
+
+interface Props {
+  groups: Group[];
+  onClickGroup: (groupId: string) => void;
+}
+
+function RecruitedPosts({ groups, onClickGroup }: Props): ReactElement {
+  if (R.isEmpty(groups)) {
+    return (
+      <EmptyStateArea
+        emptyText="모집한 팀이 없어요."
+        buttonText="팀 모집하기"
+        href="/write"
+        marginTop="80px"
+      />
+    );
+  }
+
+  return (
+    <RecruitedPostLayout>
+      {groups.map((group) => (
+        <RecruitedPost
+          key={group.groupId}
+          group={group}
+          onClick={onClickGroup}
+        />
+      ))}
+    </RecruitedPostLayout>
+  );
+}
+
+export default RecruitedPosts;
+
+const RecruitedPostLayout = styled(DetailLayout)`
+  & > :not(div:last-of-type) {
+    padding-bottom: 24px;
+    border-bottom: 0.5px solid ${palette.accent2};
+  }
+`;

--- a/src/containers/home/StatusBarContainer.tsx
+++ b/src/containers/home/StatusBarContainer.tsx
@@ -56,13 +56,15 @@ function StatusBarContainer(): ReactElement {
 
   return (
     <StatusBarWrapper>
-      <FilterBar
-        onChange={onChange}
-      />
-      <StyledDivider />
-      <TagsBar
-        tags={tagsCount}
-      />
+      <div>
+        <FilterBar
+          onChange={onChange}
+        />
+        <StyledDivider />
+        <TagsBar
+          tags={tagsCount}
+        />
+      </div>
       <RecruitmentDeadline>
         <span>모집 마감 안보기</span>
         <SwitchButton
@@ -83,6 +85,12 @@ const StatusBarWrapper = styled.div`
   align-items: center;
   margin-bottom: 20px;
   margin-top: 9px;
+
+  & > div:first-of-type {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
 `;
 
 const RecruitmentDeadline = styled.div`

--- a/src/containers/myInfo/RecruitedPostsContainer.test.tsx
+++ b/src/containers/myInfo/RecruitedPostsContainer.test.tsx
@@ -1,0 +1,56 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRouter } from 'next/router';
+
+import FIXTURE_GROUP from '../../../fixtures/group';
+import FIXTURE_PROFILE from '../../../fixtures/profile';
+
+import RecruitedPostsContainer from './RecruitedPostsContainer';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('RecruitedPostsContainer', () => {
+  const dispatch = jest.fn();
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    dispatch.mockClear();
+    mockPush.mockClear();
+
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      push: mockPush,
+    }));
+    (useDispatch as jest.Mock).mockImplementation(() => dispatch);
+    (useSelector as jest.Mock).mockImplementation((selector) => selector({
+      authReducer: {
+        user: FIXTURE_PROFILE,
+      },
+      myInfoReducer: {
+        recruitedGroups: [FIXTURE_GROUP],
+      },
+    }));
+  });
+
+  const renderRecruitedPostsContainer = () => render((
+    <RecruitedPostsContainer />
+  ));
+
+  it('렌더링 시 dispatch 액션이 호출되어야만 한다', () => {
+    renderRecruitedPostsContainer();
+
+    expect(dispatch).toBeCalledTimes(1);
+  });
+
+  describe('group을 클릭한다', () => {
+    it('router.push가 해당 글 url과 함께 호출되어야만 한다', () => {
+      renderRecruitedPostsContainer();
+
+      fireEvent.click(screen.getByText(FIXTURE_GROUP.title));
+
+      expect(mockPush).toBeCalledWith(`/detail/${FIXTURE_GROUP.groupId}`);
+    });
+  });
+});

--- a/src/containers/myInfo/RecruitedPostsContainer.tsx
+++ b/src/containers/myInfo/RecruitedPostsContainer.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useRouter } from 'next/router';
+
+import RecruitedPosts from '@/components/myInfo/RecruitedPosts';
+import { loadUserRecruitedGroups } from '@/reducers/myInfoSlice';
+import { useAppDispatch } from '@/reducers/store';
+import { getAuth, getMyInfo } from '@/utils/utils';
+
+function RecruitedPostsContainer(): ReactElement {
+  const router = useRouter();
+  const user = useSelector(getAuth('user'));
+  const groups = useSelector(getMyInfo('recruitedGroups'));
+  const dispatch = useAppDispatch();
+
+  const onClickGroup = (groupId: string) => router.push(`/detail/${groupId}`);
+
+  useEffect(() => {
+    if (user) {
+      dispatch(loadUserRecruitedGroups(user.uid));
+    }
+  }, [user]);
+
+  return (
+    <RecruitedPosts
+      onClickGroup={onClickGroup}
+      groups={groups}
+    />
+  );
+}
+
+export default RecruitedPostsContainer;

--- a/src/pages/myinfo/recruited.page.tsx
+++ b/src/pages/myinfo/recruited.page.tsx
@@ -2,20 +2,15 @@ import React, { ReactElement } from 'react';
 
 import { GetServerSideProps } from 'next';
 
-import EmptyStateArea from '@/components/common/EmptyStateArea';
 import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
+import RecruitedPostsContainer from '@/containers/myInfo/RecruitedPostsContainer';
 import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
 
 export const getServerSideProps: GetServerSideProps = authenticatedServerSideProps;
 
 function RecruitedPage(): ReactElement {
   return (
-    <EmptyStateArea
-      emptyText="모집한 팀이 없어요."
-      buttonText="팀 모집하기"
-      href="/write"
-      marginTop="80px"
-    />
+    <RecruitedPostsContainer />
   );
 }
 

--- a/src/pages/myinfo/recruited.test.tsx
+++ b/src/pages/myinfo/recruited.test.tsx
@@ -1,8 +1,24 @@
+import { useDispatch, useSelector } from 'react-redux';
+
 import { render } from '@testing-library/react';
+
+import FIXTURE_GROUP from '../../../fixtures/group';
 
 import RecruitedPage from './recruited.page';
 
 describe('RecruitedPage', () => {
+  beforeEach(() => {
+    (useDispatch as jest.Mock).mockImplementation(() => jest.fn());
+    (useSelector as jest.Mock).mockImplementation((selector) => selector({
+      authReducer: {
+        user: null,
+      },
+      myInfoReducer: {
+        recruitedGroups: [FIXTURE_GROUP],
+      },
+    }));
+  });
+
   const renderRecruitedPage = () => render((
     <RecruitedPage />
   ));
@@ -10,6 +26,6 @@ describe('RecruitedPage', () => {
   it('모집한 팀 페이지에 대한 내용이 보여야만 한다', () => {
     const { container } = renderRecruitedPage();
 
-    expect(container).toHaveTextContent('모집한 팀');
+    expect(container).toHaveTextContent(FIXTURE_GROUP.title);
   });
 });

--- a/src/reducers/myInfoSlice.test.ts
+++ b/src/reducers/myInfoSlice.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import { getUserRecruitedGroups } from '@/services/api/group';
+import { formatGroup } from '@/utils/firestore';
+
+import GROUP_FIXTURE from '../../fixtures/group';
+
+import reducer, {
+  loadUserRecruitedGroups, MyInfoStore, setMyInfoError, setRecruitedGroups,
+} from './myInfoSlice';
+
+jest.mock('@/utils/firestore');
+jest.mock('@/services/api/group');
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('myInfoReducer', () => {
+  const initialState: MyInfoStore = {
+    recruitedGroups: [],
+    myInfoError: null,
+  };
+
+  context('previous state가 undefined일 때', () => {
+    it('초기 상태 스토어가 반환되어야만 한다', () => {
+      const state = reducer(undefined, { type: 'action' });
+
+      expect(state).toEqual(initialState);
+    });
+  });
+
+  describe('setRecruitedGroups', () => {
+    it('recruitedGroups 필드가 변경되어야 한다', () => {
+      const { recruitedGroups } = reducer(initialState, setRecruitedGroups([GROUP_FIXTURE]));
+
+      expect(recruitedGroups).toEqual([GROUP_FIXTURE]);
+    });
+  });
+
+  describe('setMyInfoError', () => {
+    it('myInfoError 필드가 변경되어야 한다', () => {
+      const { myInfoError } = reducer(initialState, setMyInfoError('error'));
+
+      expect(myInfoError).toBe('error');
+    });
+  });
+});
+
+describe('groupReducer async actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  let store: any;
+
+  describe('loadUserRecruitedGroups', () => {
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    context('에러가 발생하지 않는 경우', () => {
+      beforeEach(() => {
+        (getUserRecruitedGroups as jest.Mock).mockReturnValueOnce([GROUP_FIXTURE]);
+        (formatGroup as jest.Mock).mockReturnValueOnce(GROUP_FIXTURE);
+      });
+
+      it('dispatch 액션이 "myInfo/setRecruitedGroups"인 타입과 payload는 group 리스트여야 한다', async () => {
+        await store.dispatch(loadUserRecruitedGroups('userUid'));
+
+        const actions = store.getActions();
+
+        expect(actions[0]).toEqual({
+          payload: [GROUP_FIXTURE],
+          type: 'myInfo/setRecruitedGroups',
+        });
+      });
+    });
+
+    context('에러가 발생하는 경우', () => {
+      beforeEach(() => {
+        (getUserRecruitedGroups as jest.Mock).mockImplementationOnce(() => {
+          throw new Error('error');
+        });
+      });
+
+      it('dispatch 액션이 "myInfo/setMyInfoError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
+        try {
+          await store.dispatch(loadUserRecruitedGroups('userUid'));
+        } catch (error) {
+          // ignore errors
+        } finally {
+          const actions = store.getActions();
+
+          expect(actions[0]).toEqual({
+            payload: 'error',
+            type: 'myInfo/setMyInfoError',
+          });
+        }
+      });
+    });
+  });
+});

--- a/src/reducers/myInfoSlice.ts
+++ b/src/reducers/myInfoSlice.ts
@@ -1,0 +1,55 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { Group } from '@/models/group';
+import { getUserRecruitedGroups } from '@/services/api/group';
+import { formatGroup } from '@/utils/firestore';
+
+import type { AppThunk } from './store';
+
+export interface MyInfoStore {
+  recruitedGroups: Group[];
+  myInfoError: string | null;
+}
+
+const { actions, reducer } = createSlice({
+  name: 'myInfo',
+  initialState: {
+    recruitedGroups: [],
+    myInfoError: null,
+  } as MyInfoStore,
+  reducers: {
+    setRecruitedGroups(state, { payload: recruitedGroups }: PayloadAction<Group[]>): MyInfoStore {
+      return {
+        ...state,
+        recruitedGroups,
+      };
+    },
+    setMyInfoError(state, { payload: myInfoError }: PayloadAction<string>): MyInfoStore {
+      return {
+        ...state,
+        myInfoError,
+      };
+    },
+  },
+});
+
+export const {
+  setRecruitedGroups,
+  setMyInfoError,
+} = actions;
+
+export const loadUserRecruitedGroups = (userUid: string): AppThunk => async (dispatch) => {
+  try {
+    const response = await getUserRecruitedGroups(userUid);
+
+    const groups = response.map((doc) => formatGroup(doc)) as Group[];
+
+    dispatch(setRecruitedGroups(groups));
+  } catch (error) {
+    const { message } = error as Error;
+
+    dispatch(setMyInfoError(message));
+  }
+};
+
+export default reducer;

--- a/src/reducers/rootReducer.test.ts
+++ b/src/reducers/rootReducer.test.ts
@@ -34,6 +34,10 @@ describe('rootReducer', () => {
       applicants: [],
       isVisible: false,
     },
+    myInfoReducer: {
+      recruitedGroups: [],
+      myInfoError: null,
+    },
   };
 
   context('action type이 HYDRATE일 때', () => {
@@ -60,6 +64,7 @@ describe('rootReducer', () => {
             ...initialReducer.authReducer,
             user: undefined,
           },
+          myInfoReducer: undefined,
         });
       });
     });

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -4,15 +4,18 @@ import { AnyAction } from 'redux';
 
 import authReducer, { AuthStore } from './authSlice';
 import groupReducer, { GroupStore } from './groupSlice';
+import myInfoReducer, { MyInfoStore } from './myInfoSlice';
 
 export interface RootReducerState {
-  authReducer: AuthStore,
-  groupReducer: GroupStore,
+  authReducer: AuthStore;
+  groupReducer: GroupStore;
+  myInfoReducer: MyInfoStore;
 }
 
 const combineReducer = combineReducers({
   authReducer,
   groupReducer,
+  myInfoReducer,
 });
 
 const rootReducer = (state: RootReducerState | undefined, action: AnyAction): RootReducerState => {
@@ -36,6 +39,7 @@ const rootReducer = (state: RootReducerState | undefined, action: AnyAction): Ro
         applicants: state ? state.groupReducer.applicants : [],
         comments: state ? state.groupReducer.comments : [],
       },
+      myInfoReducer: state?.myInfoReducer,
     } as RootReducerState;
   }
 

--- a/src/services/api/__mocks__/group.ts
+++ b/src/services/api/__mocks__/group.ts
@@ -5,3 +5,5 @@ export const getGroupDetail = jest.fn();
 export const getGroups = jest.fn();
 
 export const patchCompletedGroup = jest.fn();
+
+export const getUserRecruitedGroups = jest.fn();

--- a/src/services/api/group.test.ts
+++ b/src/services/api/group.test.ts
@@ -4,7 +4,7 @@ import {
 
 import { WriteFields } from '@/models/group';
 import {
-  getGroupDetail, getGroups, patchCompletedGroup, postNewGroup,
+  getGroupDetail, getGroups, getUserRecruitedGroups, patchCompletedGroup, postNewGroup,
 } from '@/services/api/group';
 
 import GROUP_FIXTURE from '../../../fixtures/group';
@@ -101,6 +101,20 @@ describe('group API', () => {
         category: [],
         isFilterCompleted: false,
       });
+
+      expect(response).toEqual([GROUP_FIXTURE]);
+    });
+  });
+
+  describe('getUserRecruitedGroups', () => {
+    beforeEach(() => {
+      (getDocs as jest.Mock).mockImplementationOnce(() => ({
+        docs: [GROUP_FIXTURE],
+      }));
+    });
+
+    it('그룹 리스트가 반환되어야만 한다', async () => {
+      const response = await getUserRecruitedGroups('userUid');
 
       expect(response).toEqual([GROUP_FIXTURE]);
     });

--- a/src/services/api/group.ts
+++ b/src/services/api/group.ts
@@ -1,5 +1,5 @@
 import {
-  addDoc, getDoc, getDocs, serverTimestamp, updateDoc,
+  addDoc, getDoc, getDocs, orderBy, query, serverTimestamp, updateDoc, where,
 } from 'firebase/firestore';
 
 import { Profile } from '@/models/auth';
@@ -41,6 +41,18 @@ export const getGroupDetail = async (uid: string) => {
 
 export const getGroups = async (condition: FilterGroupsCondition) => {
   const getQuery = getGroupsQuery(condition);
+
+  const response = await getDocs(getQuery);
+
+  return response.docs;
+};
+
+export const getUserRecruitedGroups = async (userUid: string) => {
+  const getQuery = query(
+    collectionRef('groups'),
+    where('writer.uid', '==', userUid),
+    orderBy('createdAt', 'desc'),
+  );
 
   const response = await getDocs(getQuery);
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -7,6 +7,7 @@ import {
   emptyAThenB,
   getAuth,
   getGroup,
+  getMyInfo,
   isCurrentTimeBeforeEndDate,
   isProdLevel,
   isRecruitCompletedAndManual,
@@ -82,6 +83,21 @@ test('getGroup', () => {
 
   expect(groupError(state)).toBeNull();
   expect(writeFields(state)).toEqual(WRITE_FIELDS_FIXTURE);
+});
+
+test('getMyInfo', () => {
+  const state = {
+    myInfoReducer: {
+      myInfoError: null,
+      recruitedGroups: [GROUP_FIXTURE],
+    },
+  } as RootReducerState;
+
+  const myInfoError = getMyInfo('myInfoError');
+  const recruitedGroups = getMyInfo('recruitedGroups');
+
+  expect(myInfoError(state)).toBeNull();
+  expect(recruitedGroups(state)).toEqual([GROUP_FIXTURE]);
 });
 
 describe('stringToExcludeNull', () => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { Group } from '@/models/group';
 import type { AuthStore } from '@/reducers/authSlice';
 import type { GroupStore } from '@/reducers/groupSlice';
+import type { MyInfoStore } from '@/reducers/myInfoSlice';
 import type { AppState } from '@/reducers/store';
 
 export const isProdLevel = (env: string): boolean => env === 'production';
@@ -14,6 +15,10 @@ export const getAuth = <K extends keyof AuthStore>(
 export const getGroup = <K extends keyof GroupStore>(
   key: K,
 ) => (obj: AppState) => obj.groupReducer[key];
+
+export const getMyInfo = <K extends keyof MyInfoStore>(
+  key: K,
+) => (obj: AppState) => obj.myInfoReducer[key];
 
 export const stringToExcludeNull = (value?: string | null): string => {
   if (typeof value === 'undefined') {


### PR DESCRIPTION
- 내 정보 페이지에서 내가 모집한 팀을 볼 수 있다.
- 해당 팀 클릭시 해당 페이지로 이동

<img width="760" alt="스크린샷 2022-01-28 오후 11 50 44" src="https://user-images.githubusercontent.com/60910665/151568211-2aa50952-66bd-44be-a0c1-06015201c99c.png">

