### PR TITLE
[Fix] 로그아웃시 메인 페이지로 이동시켜라

### DIFF
--- a/src/containers/common/HeaderContainer.test.tsx
+++ b/src/containers/common/HeaderContainer.test.tsx
@@ -15,9 +15,11 @@ jest.mock('next/router', () => ({
 
 describe('HeaderContainer', () => {
   const dispatch = jest.fn();
+  const replace = jest.fn();
 
   beforeEach(() => {
     dispatch.mockClear();
+    replace.mockClear();
 
     (useDispatch as jest.Mock).mockImplementation(() => dispatch);
     (useSelector as jest.Mock).mockImplementation((selector) => selector({
@@ -27,6 +29,7 @@ describe('HeaderContainer', () => {
     }));
     (useRouter as jest.Mock).mockImplementation(() => ({
       pathname: '/',
+      replace,
     }));
   });
 
@@ -80,6 +83,7 @@ describe('HeaderContainer', () => {
         fireEvent.click(screen.getByText('로그아웃'));
 
         expect(dispatch).toBeCalled();
+        expect(replace).toBeCalledWith('/');
       });
     });
   });

--- a/src/containers/common/HeaderContainer.tsx
+++ b/src/containers/common/HeaderContainer.tsx
@@ -11,13 +11,16 @@ import { useAppDispatch } from '@/reducers/store';
 import { getAuth } from '@/utils/utils';
 
 function HeaderContainer(): ReactElement {
-  const router = useRouter();
+  const { replace, pathname } = useRouter();
   const dispatch = useAppDispatch();
   const user = useSelector(getAuth('user'));
   const [isScrollTop, setIsScrollTop] = useState<boolean>(true);
 
   const onClickSignIn = useCallback(() => dispatch(setSignInModalVisible(true)), [dispatch]);
-  const signOut = useCallback(() => dispatch(requestSignOut()), [dispatch]);
+  const signOut = useCallback(() => {
+    dispatch(requestSignOut());
+    replace('/');
+  }, [dispatch]);
 
   const handleScrollAction = () => setIsScrollTop(window.scrollY === 0);
 
@@ -33,7 +36,7 @@ function HeaderContainer(): ReactElement {
       isScrollTop={isScrollTop}
       onClick={onClickSignIn}
       user={user}
-      isHome={router.pathname === '/'}
+      isHome={pathname === '/'}
     />
   );
 }

--- a/src/containers/home/RecruitPostsContainer.test.tsx
+++ b/src/containers/home/RecruitPostsContainer.test.tsx
@@ -34,6 +34,7 @@ describe('RecruitPostsContainer', () => {
       query: {
         error: given.error,
       },
+      replace: jest.fn(),
     }));
   });
 

--- a/src/containers/home/RecruitPostsContainer.tsx
+++ b/src/containers/home/RecruitPostsContainer.tsx
@@ -11,7 +11,7 @@ import { useAppDispatch } from '@/reducers/store';
 import { getGroup } from '@/utils/utils';
 
 function RecruitPostsContainer(): ReactElement {
-  const { query } = useRouter();
+  const { query, replace } = useRouter();
   const dispatch = useAppDispatch();
   const groups = useSelector(getGroup('groups'));
 
@@ -23,6 +23,7 @@ function RecruitPostsContainer(): ReactElement {
   useEffect(() => {
     if (query.error === 'unauthenticated') {
       toast.error('해당 페이지를 볼 수 있는 권한이 없어요!');
+      replace('/', undefined, { shallow: true });
     }
   }, [query]);
 


### PR DESCRIPTION
- 로그아웃시 메인 페이지로 이동시킨다.
- 권한이 없는 페이지에서 main으로 redirect된 경우 query를 삭제하여 다시 toast가 뜨지 않게 변경