### PR TITLE
[Imporve] Main Page에서 호출 중인 API를 React Query를 적용하라

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,12 @@
+/* eslint-disable no-console */
+import { setLogger } from 'react-query';
+
 import '@testing-library/jest-dom/extend-expect';
 import 'jest-plugin-context/setup';
 import 'given2/setup';
+
+setLogger({
+  log: console.log,
+  warn: console.warn,
+  error: () => {},
+});

--- a/package.json
+++ b/package.json
@@ -58,10 +58,12 @@
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9",
     "react-hook-form": "^7.20.4",
+    "react-query": "^3.34.12",
     "react-redux": "^7.2.6",
     "react-toastify": "^8.1.0",
     "react-toggle": "^4.1.2",
     "react-use": "^17.3.1",
+    "recoil": "^0.6.1",
     "redux": "^4.1.2",
     "yup": "^0.32.11"
   },

--- a/src/components/home/TagsBar.test.tsx
+++ b/src/components/home/TagsBar.test.tsx
@@ -3,27 +3,29 @@ import { render } from '@testing-library/react';
 import TagsBar from './TagsBar';
 
 describe('TagsBar', () => {
+  const tags = [
+    { name: 'test', count: 1 },
+    { name: 'test1', count: 0 },
+  ];
+
   const renderTagsBar = () => render((
     <TagsBar
-      tags={given.tags}
+      isLoading={given.isLoading}
+      tags={tags}
     />
   ));
 
-  context('tag들이 존재하지 않는 경우', () => {
-    given('tags', () => []);
+  context('로딩중인 경우', () => {
+    given('isLoading', () => true);
 
-    it('"태그가 없어요!" 문구가 나타나야만 한다', () => {
+    it('"로딩중..." 문구가 나타나야만 한다', () => {
       const { container } = renderTagsBar();
 
-      expect(container).toHaveTextContent('태그가 없어요!');
+      expect(container).toHaveTextContent('로딩중...');
     });
   });
 
-  context('tag들이 존재하는 경우', () => {
-    const tags = [{ name: 'test' }, { name: 'test1' }];
-
-    given('tags', () => tags);
-
+  context('로딩중이 아닌 경우', () => {
     it('태그들이 나타나야만 한다', () => {
       const { container } = renderTagsBar();
 

--- a/src/components/home/TagsBar.tsx
+++ b/src/components/home/TagsBar.tsx
@@ -8,11 +8,12 @@ import Tag from '../common/Tag';
 
 interface Props {
   tags: TagCount[];
+  isLoading: boolean;
 }
 
-function TagsBar({ tags }: Props): ReactElement {
-  if (!tags.length) {
-    return <>태그가 없어요!</>;
+function TagsBar({ tags, isLoading }: Props): ReactElement {
+  if (isLoading) {
+    return <div>로딩중...</div>;
   }
 
   return (

--- a/src/containers/home/RecruitPostsContainer.test.tsx
+++ b/src/containers/home/RecruitPostsContainer.test.tsx
@@ -1,13 +1,15 @@
-import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
 
 import { render } from '@testing-library/react';
 import { useRouter } from 'next/router';
 
+import useFetchGroups from '@/hooks/api/useFetchGroups';
+
 import GROUP_FIXTURE from '../../../fixtures/group';
 
 import RecruitPostsContainer from './RecruitPostsContainer';
 
+jest.mock('@/hooks/api/useFetchGroups');
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }));
@@ -18,17 +20,13 @@ jest.mock('react-toastify', () => ({
 }));
 
 describe('RecruitPostsContainer', () => {
-  const dispatch = jest.fn();
-
   beforeEach(() => {
-    dispatch.mockClear();
     jest.clearAllMocks();
 
-    (useDispatch as jest.Mock).mockImplementation(() => dispatch);
-    (useSelector as jest.Mock).mockImplementation((selector) => selector({
-      groupReducer: {
-        groups: given.groups,
-      },
+    (useFetchGroups as jest.Mock).mockImplementation(() => ({
+      data: [GROUP_FIXTURE],
+      isLoading: given.isLoading,
+      isError: given.isError,
     }));
     (useRouter as jest.Mock).mockImplementation(() => ({
       query: {
@@ -42,14 +40,8 @@ describe('RecruitPostsContainer', () => {
     <RecruitPostsContainer />
   ));
 
-  it('초기 렌더링에 dispatch 액션이 호출되어야만 한다', () => {
-    renderRecruitPostsContainer();
-
-    expect(dispatch).toBeCalledTimes(1);
-  });
-
-  context('그룹 리스트가 존재하지 않는 경우', () => {
-    given('groups', () => []);
+  context('로딩중인 경우', () => {
+    given('isLoading', () => true);
 
     it('"로딩중..."문구가 보여야만 한다', () => {
       const { container } = renderRecruitPostsContainer();
@@ -58,35 +50,33 @@ describe('RecruitPostsContainer', () => {
     });
   });
 
-  context('그룹 리스트가 존재하는 경우', () => {
-    given('groups', () => [GROUP_FIXTURE]);
+  context('에러가 존재하는 경우', () => {
+    given('isError', () => true);
 
+    describe('신청현황 페이지에서 권한이 없어서 Redirect여부에 따라 메시지가 보인다', () => {
+      context('query에 error가 "unauthenticated"인 경우', () => {
+        given('error', () => ('unauthenticated'));
+
+        it('toast.error가 호출되어야만 한다', () => {
+          renderRecruitPostsContainer();
+
+          expect(toast.error).toBeCalledWith('해당 페이지를 볼 수 있는 권한이 없어요!');
+        });
+      });
+    });
+
+    it('toast.error가 호출되어야만 한다', () => {
+      renderRecruitPostsContainer();
+
+      expect(toast.error).toBeCalledWith('팀 리스트를 불러오는데 실패했어요! 다시 시도해주세요!');
+    });
+  });
+
+  context('그룹 리스트가 존재하는 경우', () => {
     it('그룹 리스트가 보여야만 한다', () => {
       const { container } = renderRecruitPostsContainer();
 
       expect(container).toHaveTextContent('title');
-    });
-  });
-
-  describe('신청현황 페이지에서 권한이 없어서 Redirect여부에 따라 메시지가 보인다', () => {
-    context('query에 error가 "unauthenticated"인 경우', () => {
-      given('error', () => ('unauthenticated'));
-
-      it('toast.error가 호출되어야만 한다', () => {
-        renderRecruitPostsContainer();
-
-        expect(toast.error).toBeCalledWith('해당 페이지를 볼 수 있는 권한이 없어요!');
-      });
-    });
-
-    context('query에 error가 없을 경우', () => {
-      given('error', () => (''));
-
-      it('toast.error가 호출되지 않아야만 한다', () => {
-        renderRecruitPostsContainer();
-
-        expect(toast.error).not.toBeCalled();
-      });
     });
   });
 });

--- a/src/containers/home/RecruitPostsContainer.tsx
+++ b/src/containers/home/RecruitPostsContainer.tsx
@@ -1,24 +1,14 @@
 import React, { ReactElement, useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
-import { useEffectOnce } from 'react-use';
 
 import { useRouter } from 'next/router';
 
 import RecruitPosts from '@/components/home/RecruitPosts';
-import { loadGroups } from '@/reducers/groupSlice';
-import { useAppDispatch } from '@/reducers/store';
-import { getGroup } from '@/utils/utils';
+import useFetchGroups from '@/hooks/api/useFetchGroups';
 
 function RecruitPostsContainer(): ReactElement {
   const { query, replace } = useRouter();
-  const dispatch = useAppDispatch();
-  const groups = useSelector(getGroup('groups'));
-
-  useEffectOnce(() => dispatch(loadGroups({
-    category: ['study', 'project'],
-    isFilterCompleted: false,
-  })));
+  const { data: groups, isLoading, isError } = useFetchGroups();
 
   useEffect(() => {
     if (query.error === 'unauthenticated') {
@@ -27,8 +17,14 @@ function RecruitPostsContainer(): ReactElement {
     }
   }, [query]);
 
-  if (!groups || !groups.length) {
-    return <div>로딩중...</div>;
+  useEffect(() => {
+    if (isError) {
+      toast.error('팀 리스트를 불러오는데 실패했어요! 다시 시도해주세요!');
+    }
+  }, [isError]);
+
+  if (isLoading) {
+    return <>로딩중...</>;
   }
 
   return (

--- a/src/containers/home/StatusBarContainer.test.tsx
+++ b/src/containers/home/StatusBarContainer.test.tsx
@@ -1,59 +1,86 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
 
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import useFetchTagsCount from '@/hooks/api/useFetchTagsCount';
+import InjectTestingRecoilState from '@/test/InjectTestingRecoilState';
+
 import StatusBarContainer from './StatusBarContainer';
 
+jest.mock('@/hooks/api/useFetchTagsCount');
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
 describe('StatusBarContainer', () => {
-  const dispatch = jest.fn();
-
   beforeEach(() => {
-    dispatch.mockClear();
+    jest.clearAllMocks();
 
-    (useDispatch as jest.Mock).mockImplementation(() => dispatch);
-    (useSelector as jest.Mock).mockImplementation((selector) => selector({
-      groupReducer: {
-        tagsCount: [],
-      },
+    (useFetchTagsCount as jest.Mock).mockImplementation(() => ({
+      data: [{ name: 'javascript' }],
+      isError: given.isError,
+      isLoading: false,
     }));
   });
 
   const renderStatusBarContainer = () => render((
-    <StatusBarContainer />
+    <InjectTestingRecoilState>
+      <StatusBarContainer />
+    </InjectTestingRecoilState>
   ));
 
-  it('초기 렌더링에 dispatch 액션이 호출되어야만 한다', () => {
-    renderStatusBarContainer();
+  describe('태그 정보에 대한 이벤트', () => {
+    context('tagsCount 액션이 에러가 발생한 경우', () => {
+      given('isError', () => true);
 
-    expect(dispatch).toBeCalledTimes(1);
-  });
+      it('"toast.error"가 호출되어야만 한다', () => {
+        renderStatusBarContainer();
 
-  context('filter가 존재하지 않는 경우', () => {
-    it('dispatch 액션이 호출되야만 한다', () => {
-      renderStatusBarContainer();
-
-      fireEvent.change(screen.getByDisplayValue('전체'), {
-        target: { value: '' },
+        expect(toast.error).toBeCalledWith('태그를 불러올 수 없어요!');
       });
+    });
 
-      expect(dispatch).toBeCalled();
+    context('tagsCount 액션이 에러가 발생하지 않은 경우', () => {
+      given('isError', () => false);
+
+      it('"toast.error"가 호출되지 않아야만 한다', () => {
+        renderStatusBarContainer();
+
+        expect(toast.error).not.toBeCalled();
+      });
     });
   });
 
-  context('filter가 존재하는 경우', () => {
-    it('dispatch 액션이 호출되야만 한다', () => {
-      renderStatusBarContainer();
+  describe('필터 select를 변경한다', () => {
+    context('category가 존재하지 않는 경우', () => {
+      it('"전체"가 보여야만 한다', () => {
+        const { container } = renderStatusBarContainer();
 
-      fireEvent.change(screen.getByDisplayValue('전체'), {
-        target: { value: 'study' },
+        fireEvent.change(screen.getByDisplayValue('전체'), {
+          target: { value: '' },
+        });
+
+        expect(container).toHaveTextContent('전체');
       });
+    });
 
-      expect(dispatch).toBeCalled();
+    context('filter가 존재하는 경우', () => {
+      it('"스터디"가 보여야만 한다', () => {
+        const { container } = renderStatusBarContainer();
+
+        fireEvent.change(screen.getByDisplayValue('전체'), {
+          target: { value: 'study' },
+        });
+
+        expect(container).toHaveTextContent('스터디');
+      });
     });
   });
 
   describe('"모집 마감 안보기" switch 버튼을 클릭한다', () => {
-    it('switch 버튼의 checked 속성이 존재해야만 한다', () => {
+    it('recoil set이 호출되어야만 한다', () => {
       renderStatusBarContainer();
 
       const button = screen.getByTestId('switch-button');
@@ -61,7 +88,6 @@ describe('StatusBarContainer', () => {
       fireEvent.click(button);
 
       expect(button).toHaveAttribute('checked');
-      expect(dispatch).toBeCalled();
     });
   });
 });

--- a/src/hooks/api/useFetchGroups.test.ts
+++ b/src/hooks/api/useFetchGroups.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { getFilteredGroups } from '@/services/api/group';
+import wrapper from '@/test/InjectMockProviders';
+
+import FIXTURE_GROUP from '../../../fixtures/group';
+
+import useFetchGroups from './useFetchGroups';
+
+jest.mock('@/services/api/group');
+
+describe('useFetchGroups', () => {
+  const useFetchGroupsHook = () => renderHook(() => useFetchGroups(), { wrapper });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getFilteredGroups as jest.Mock).mockImplementation(() => (given.groups));
+  });
+
+  context('useQuery반환값이 존재하지 않는 경우', () => {
+    given('groups', () => null);
+
+    it('빈 배열을 반환해야만 한다', async () => {
+      const { result, waitFor } = useFetchGroupsHook();
+
+      await waitFor(() => !!result.current.data);
+
+      expect(result.current.data).toEqual([]);
+    });
+  });
+
+  context('useQuery반환값이 존재하는 경우', () => {
+    given('groups', () => [FIXTURE_GROUP]);
+
+    it('groups에 대한 정보를 반환해야만 한다', async () => {
+      const { result, waitFor } = useFetchGroupsHook();
+
+      await waitFor(() => !!result.current.data);
+
+      expect(result.current.data).toEqual([FIXTURE_GROUP]);
+    });
+  });
+});

--- a/src/hooks/api/useFetchGroups.ts
+++ b/src/hooks/api/useFetchGroups.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+
+import { FirestoreError } from 'firebase/firestore';
+import { useRecoilValue } from 'recoil';
+
+import { Group } from '@/models/group';
+import { groupsConditionState } from '@/recoil/group/atom';
+import { getFilteredGroups } from '@/services/api/group';
+
+function useFetchGroups() {
+  const groupsCondition = useRecoilValue(groupsConditionState);
+
+  const query = useQuery<Group[], FirestoreError>(['groups', groupsCondition], () => getFilteredGroups(groupsCondition));
+
+  useEffect(() => {
+    query.refetch();
+  }, [groupsCondition]);
+
+  return {
+    ...query,
+    data: query?.data ?? [],
+  };
+}
+
+export default useFetchGroups;

--- a/src/hooks/api/useFetchTagsCount.test.ts
+++ b/src/hooks/api/useFetchTagsCount.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { getTagsCount } from '@/services/api/tagsCount';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import useFetchTagsCount from './useFetchTagsCount';
+
+jest.mock('@/services/api/tagsCount');
+
+describe('useFetchTagsCount', () => {
+  const useFetchTagsCountHook = () => renderHook(() => useFetchTagsCount(), { wrapper });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getTagsCount as jest.Mock).mockImplementation(() => (given.tagsCount));
+  });
+
+  context('useQuery 반환값이 존재하지 않는 경우', () => {
+    given('tagsCount', () => null);
+
+    it('빈 배열을 반환해야만 한다', async () => {
+      const { result, waitFor } = useFetchTagsCountHook();
+
+      await waitFor(() => !!result.current.data);
+
+      expect(result.current.data).toEqual([]);
+    });
+  });
+
+  context('useQuery 반환값이 존재하는 경우', () => {
+    const tagsCount = [
+      { name: 'JavaScript' },
+      { count: 1 },
+    ];
+
+    given('tagsCount', () => tagsCount);
+
+    it('groups에 대한 정보를 반환해야만 한다', async () => {
+      const { result, waitFor } = useFetchTagsCountHook();
+
+      await waitFor(() => !!result.current.data);
+
+      expect(result.current.data).toEqual(tagsCount);
+    });
+  });
+});

--- a/src/hooks/api/useFetchTagsCount.ts
+++ b/src/hooks/api/useFetchTagsCount.ts
@@ -1,0 +1,17 @@
+import { useQuery } from 'react-query';
+
+import { FirestoreError } from 'firebase/firestore';
+
+import { TagCount } from '@/models/group';
+import { getTagsCount } from '@/services/api/tagsCount';
+
+function useFetchTagsCount() {
+  const query = useQuery<TagCount[], FirestoreError>('tagsCount', () => getTagsCount());
+
+  return {
+    ...query,
+    data: query?.data ?? [],
+  };
+}
+
+export default useFetchTagsCount;

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import type { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, useState } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
+import { RecoilRoot } from 'recoil';
 
 import AuthProvider from '@/components/common/AuthProvider';
 import Core from '@/components/common/Core';
@@ -19,15 +22,26 @@ type AppPropsWithLayout = AppProps & {
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page);
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+      },
+    },
+  }));
 
   return getLayout((
-    <>
-      <Core />
-      <AuthProvider>
-        <SignInModalContainer />
-        <Component {...pageProps} />
-      </AuthProvider>
-    </>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <Core />
+        <AuthProvider>
+          <SignInModalContainer />
+          <Component {...pageProps} />
+        </AuthProvider>
+      </RecoilRoot>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   ));
 }
 

--- a/src/pages/index.test.tsx
+++ b/src/pages/index.test.tsx
@@ -1,7 +1,9 @@
-import { useDispatch, useSelector } from 'react-redux';
-
 import { render } from '@testing-library/react';
 import { useRouter } from 'next/router';
+
+import useFetchGroups from '@/hooks/api/useFetchGroups';
+import useFetchTagsCount from '@/hooks/api/useFetchTagsCount';
+import InjectTestingRecoilState from '@/test/InjectTestingRecoilState';
 
 import GROUP_FIXTURE from '../../fixtures/group';
 
@@ -10,20 +12,16 @@ import HomePage from './index.page';
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }));
+jest.mock('@/hooks/api/useFetchGroups');
+jest.mock('@/hooks/api/useFetchTagsCount');
 
 describe('HomePage', () => {
-  const dispatch = jest.fn();
-
   beforeEach(() => {
-    (useDispatch as jest.Mock).mockImplementation(() => dispatch);
-    (useSelector as jest.Mock).mockImplementation((selector) => selector({
-      authReducer: {
-        user: null,
-      },
-      groupReducer: {
-        groups: [GROUP_FIXTURE],
-        tagsCount: [],
-      },
+    (useFetchGroups as jest.Mock).mockImplementation(() => ({
+      data: [GROUP_FIXTURE],
+    }));
+    (useFetchTagsCount as jest.Mock).mockImplementation(() => ({
+      data: [{ name: 'javascript' }],
     }));
     (useRouter as jest.Mock).mockImplementation(() => ({
       asPath: '/',
@@ -34,7 +32,9 @@ describe('HomePage', () => {
   });
 
   const renderHome = () => render((
-    <HomePage />
+    <InjectTestingRecoilState>
+      <HomePage />
+    </InjectTestingRecoilState>
   ));
 
   it('홈에 대한 정보가 보여져야만 한다', () => {
@@ -43,52 +43,3 @@ describe('HomePage', () => {
     expect(container).toHaveTextContent('시작하기');
   });
 });
-
-// describe('getServerSideProps', () => {
-//   beforeEach(() => {
-//     jest.clearAllMocks();
-//     jest.spyOn(window.console, 'log').mockImplementation(() => null);
-//   });
-
-//   const mockContext = {
-//     params: { id: 'test' } as ParsedUrlQuery,
-//   };
-
-//   context('세션이 존재할 경우', () => {
-//     beforeEach(() => {
-//       (getSession as jest.Mock).mockReturnValueOnce({
-//         user: 'user',
-//       });
-//     });
-
-//     it('세션 정보와 store 정보가 반환되어야 한다', async () => {
-//       const result = await getServerSideProps(mockContext as GetServerSidePropsContext);
-
-//       expect(result).toEqual({
-//         props: {
-//           ...INITIAL_STORE_FIXTURE,
-//           session: {
-//             user: 'user',
-//           },
-//         },
-//       });
-//     });
-//   });
-
-//   context('세션이 존재하지 않은 경우', () => {
-//     beforeEach(() => {
-//       (getSession as jest.Mock).mockReturnValueOnce(null);
-//     });
-
-//     it('세션 정보가 undefined를 반환해야만 한다', async () => {
-//       const result = await getServerSideProps(mockContext as GetServerSidePropsContext);
-
-//       expect(result).toEqual({
-//         props: {
-//           ...INITIAL_STORE_FIXTURE,
-//           session: null,
-//         },
-//       });
-//     });
-//   });
-// });

--- a/src/recoil/group/atom.ts
+++ b/src/recoil/group/atom.ts
@@ -1,0 +1,12 @@
+/* eslint-disable import/prefer-default-export */
+import { atom } from 'recoil';
+
+import { FilterGroupsCondition } from '@/models/group';
+
+export const groupsConditionState = atom<FilterGroupsCondition>({
+  key: 'groupsConditionState',
+  default: {
+    category: ['study', 'project'],
+    isFilterCompleted: false,
+  },
+});

--- a/src/reducers/groupSlice.test.ts
+++ b/src/reducers/groupSlice.test.ts
@@ -8,10 +8,10 @@ import {
 } from '@/services/api/applicants';
 import { deleteGroupComment, getGroupComments, postGroupComment } from '@/services/api/comment';
 import {
-  getGroupDetail, getGroups, patchCompletedGroup, patchNumberApplicants, postNewGroup,
+  getGroupDetail, patchCompletedGroup, patchNumberApplicants, postNewGroup,
 } from '@/services/api/group';
-import { getTagsCount, updateTagCount } from '@/services/api/tagsCount';
-import { formatApplicant, formatComment, formatGroup } from '@/utils/firestore';
+import { updateTagCount } from '@/services/api/tagsCount';
+import { formatApplicant, formatComment } from '@/utils/firestore';
 
 import APPLICANT_FIXTURE from '../../fixtures/applicant';
 import COMMENT_FIXTURE from '../../fixtures/comment';
@@ -26,8 +26,6 @@ import reducer, {
   loadApplicants,
   loadComments,
   loadGroupDetail,
-  loadGroups,
-  loadTagsCount,
   requestAddApplicant,
   requestAddComment,
   requestDeleteApplicant,
@@ -289,124 +287,6 @@ describe('groupReducer async actions', () => {
       it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
         try {
           await store.dispatch(loadGroupDetail('id'));
-        } catch (error) {
-          // ignore errors
-        } finally {
-          const actions = store.getActions();
-
-          expect(actions[0]).toEqual({
-            payload: 'error',
-            type: 'group/setGroupError',
-          });
-        }
-      });
-    });
-  });
-
-  describe('loadGroups', () => {
-    beforeEach(() => {
-      store = mockStore({});
-    });
-
-    context('에러가 발생하지 않는 경우', () => {
-      beforeEach(() => {
-        (getGroups as jest.Mock).mockReturnValueOnce([GROUP_FIXTURE]);
-        (formatGroup as jest.Mock).mockReturnValueOnce(GROUP_FIXTURE);
-      });
-
-      context('isFilterCompleted가 true인 경우', () => {
-        it('dispatch 액션이 "group/setGroups"인 타입과 payload는 group 리스트여야 한다', async () => {
-          await store.dispatch(loadGroups({
-            category: ['study', 'project'],
-            isFilterCompleted: true,
-          }));
-
-          const actions = store.getActions();
-
-          expect(actions[0]).toEqual({
-            payload: [GROUP_FIXTURE],
-            type: 'group/setGroups',
-          });
-        });
-      });
-
-      context('isFilterCompleted가 false인 경우', () => {
-        it('dispatch 액션이 "group/setGroups"인 타입과 payload는 group 리스트여야 한다', async () => {
-          await store.dispatch(loadGroups({
-            category: ['study', 'project'],
-            isFilterCompleted: false,
-          }));
-
-          const actions = store.getActions();
-
-          expect(actions[0]).toEqual({
-            payload: [GROUP_FIXTURE],
-            type: 'group/setGroups',
-          });
-        });
-      });
-    });
-
-    context('에러가 발생하는 경우', () => {
-      beforeEach(() => {
-        (getGroups as jest.Mock).mockImplementationOnce(() => {
-          throw new Error('error');
-        });
-      });
-
-      it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
-        try {
-          await store.dispatch(loadGroups({
-            category: ['study', 'project'],
-            isFilterCompleted: false,
-          }));
-        } catch (error) {
-          // ignore errors
-        } finally {
-          const actions = store.getActions();
-
-          expect(actions[0]).toEqual({
-            payload: 'error',
-            type: 'group/setGroupError',
-          });
-        }
-      });
-    });
-  });
-
-  describe('loadTagsCount', () => {
-    beforeEach(() => {
-      store = mockStore({});
-    });
-    const responseTags = { name: 'test', count: 1 };
-
-    context('에러가 발생하지 않는 경우', () => {
-      (getTagsCount as jest.Mock).mockImplementationOnce(() => ([
-        {
-          data: jest.fn().mockReturnValue(responseTags),
-        },
-      ]));
-
-      it('dispatch 액션이 "group/setTagsCount"인 타입과 payload는 tag 리스트여야 한다', async () => {
-        await store.dispatch(loadTagsCount());
-
-        const actions = store.getActions();
-
-        expect(actions[0]).toEqual({
-          payload: [responseTags],
-          type: 'group/setTagsCount',
-        });
-      });
-    });
-
-    context('에러가 발생하는 경우', () => {
-      (getTagsCount as jest.Mock).mockImplementationOnce(() => {
-        throw new Error('error');
-      });
-
-      it('dispatch 액션이 "group/setGroupError"인 타입과 오류 메시지 payload 이어야 한다', async () => {
-        try {
-          await store.dispatch(loadTagsCount());
         } catch (error) {
           // ignore errors
         } finally {

--- a/src/reducers/groupSlice.ts
+++ b/src/reducers/groupSlice.ts
@@ -6,7 +6,6 @@ import {
   Applicant,
   Comment,
   CommentFields,
-  FilterGroupsCondition,
   Group, TagCount, WriteFields, WriteFieldsForm,
 } from '@/models/group';
 import {
@@ -14,11 +13,10 @@ import {
 } from '@/services/api/applicants';
 import { deleteGroupComment, getGroupComments, postGroupComment } from '@/services/api/comment';
 import {
-  getGroupDetail, getGroups, patchCompletedGroup, patchNumberApplicants, postNewGroup,
+  getGroupDetail, patchCompletedGroup, patchNumberApplicants, postNewGroup,
 } from '@/services/api/group';
-import { getTagsCount, updateTagCount } from '@/services/api/tagsCount';
-import { formatApplicant, formatComment, formatGroup } from '@/utils/firestore';
-import { isRecruiting } from '@/utils/utils';
+import { updateTagCount } from '@/services/api/tagsCount';
+import { formatApplicant, formatComment } from '@/utils/firestore';
 
 import type { AppThunk } from './store';
 
@@ -183,42 +181,6 @@ export const loadGroupDetail = (id: string): AppThunk => async (dispatch) => {
     const group = await getGroupDetail(id);
 
     dispatch(setGroup(group));
-  } catch (error) {
-    const { message } = error as Error;
-
-    dispatch(setGroupError(message));
-  }
-};
-
-export const loadGroups = (condition: FilterGroupsCondition): AppThunk => async (dispatch) => {
-  try {
-    const response = await getGroups(condition);
-
-    const groups = response.map(formatGroup) as Group[];
-
-    const filteredGroups = groups.filter((group) => {
-      if (condition.isFilterCompleted && isRecruiting(group)) {
-        return group;
-      }
-
-      return group;
-    });
-
-    dispatch(setGroups(filteredGroups));
-  } catch (error) {
-    const { message } = error as Error;
-
-    dispatch(setGroupError(message));
-  }
-};
-
-export const loadTagsCount = (): AppThunk => async (dispatch) => {
-  try {
-    const response = await getTagsCount();
-
-    const tagsCount = response.map((doc) => doc.data()) as TagCount[];
-
-    dispatch(setTagsCount(tagsCount));
   } catch (error) {
     const { message } = error as Error;
 

--- a/src/services/api/__mocks__/group.ts
+++ b/src/services/api/__mocks__/group.ts
@@ -9,3 +9,5 @@ export const patchCompletedGroup = jest.fn();
 export const getUserRecruitedGroups = jest.fn();
 
 export const patchNumberApplicants = jest.fn();
+
+export const getFilteredGroups = jest.fn();

--- a/src/services/api/group.test.ts
+++ b/src/services/api/group.test.ts
@@ -4,6 +4,7 @@ import {
 
 import { WriteFields } from '@/models/group';
 import {
+  getFilteredGroups,
   getGroupDetail,
   getGroups,
   getUserRecruitedGroups,
@@ -11,6 +12,7 @@ import {
   patchNumberApplicants,
   postNewGroup,
 } from '@/services/api/group';
+import { formatGroup } from '@/utils/firestore';
 
 import GROUP_FIXTURE from '../../../fixtures/group';
 import PROFILE_FIXTURE from '../../../fixtures/profile';
@@ -109,6 +111,37 @@ describe('group API', () => {
       });
 
       expect(response).toEqual([GROUP_FIXTURE]);
+    });
+  });
+
+  describe('getFilteredGroups', () => {
+    beforeEach(() => {
+      (getDocs as jest.Mock).mockImplementationOnce(() => ({
+        docs: [GROUP_FIXTURE],
+      }));
+      (formatGroup as jest.Mock).mockReturnValueOnce(GROUP_FIXTURE);
+    });
+
+    context('isFilterCompleted가 true인 경우', () => {
+      it('그룹 리스트가 반환되어야만 한다', async () => {
+        const response = await getFilteredGroups({
+          category: ['study', 'project'],
+          isFilterCompleted: true,
+        });
+
+        expect(response).toEqual([GROUP_FIXTURE]);
+      });
+    });
+
+    context('isFilterCompleted가 false인 경우', () => {
+      it('그룹 리스트가 반환되어야만 한다', async () => {
+        const response = await getFilteredGroups({
+          category: ['study', 'project'],
+          isFilterCompleted: false,
+        });
+
+        expect(response).toEqual([GROUP_FIXTURE]);
+      });
     });
   });
 

--- a/src/services/api/group.ts
+++ b/src/services/api/group.ts
@@ -13,7 +13,8 @@ import { Profile } from '@/models/auth';
 import {
   FilterGroupsCondition, Group, WriteFields,
 } from '@/models/group';
-import { timestampToString } from '@/utils/firestore';
+import { formatGroup, timestampToString } from '@/utils/firestore';
+import { isRecruiting } from '@/utils/utils';
 
 import { collectionRef, docRef } from '../firebase';
 import { getGroupsQuery } from '../firebase/getQuery';
@@ -55,6 +56,20 @@ export const getGroups = async (condition: FilterGroupsCondition) => {
   const response = await getDocs(getQuery);
 
   return response.docs;
+};
+
+export const getFilteredGroups = async (condition: FilterGroupsCondition) => {
+  const groups = await getGroups(condition);
+
+  const filteredGroups = (groups.map(formatGroup) as Group[]).filter((group) => {
+    if (condition.isFilterCompleted && isRecruiting(group)) {
+      return group;
+    }
+
+    return group;
+  });
+
+  return filteredGroups;
 };
 
 export const getUserRecruitedGroups = async (userUid: string) => {

--- a/src/services/api/tagsCount.test.ts
+++ b/src/services/api/tagsCount.test.ts
@@ -12,20 +12,22 @@ describe('tagsCount API', () => {
   });
 
   describe('getTagsCount', () => {
-    const tagsCount = [
-      { name: 'test', count: 1 },
-    ];
+    const tagCount = {
+      name: 'test', count: 1,
+    };
 
     beforeEach(() => {
       (getDocs as jest.Mock).mockImplementationOnce(() => ({
-        docs: tagsCount,
+        docs: [{
+          data: jest.fn().mockReturnValue(tagCount),
+        }],
       }));
     });
 
     it('테그 리스트가 반환되어야만 한다', async () => {
       const response = await getTagsCount();
 
-      expect(response).toEqual(tagsCount);
+      expect(response).toEqual([tagCount]);
     });
   });
 

--- a/src/services/api/tagsCount.ts
+++ b/src/services/api/tagsCount.ts
@@ -2,6 +2,8 @@ import {
   getDoc, getDocs, limit, orderBy, query, setDoc, updateDoc,
 } from 'firebase/firestore';
 
+import { TagCount } from '@/models/group';
+
 import { collectionRef, docRef } from '../firebase';
 
 export const getTagsCount = async () => {
@@ -13,7 +15,7 @@ export const getTagsCount = async () => {
 
   const response = await getDocs(getQuery);
 
-  return response.docs;
+  return response.docs.map((doc) => doc.data()) as TagCount[];
 };
 
 export const updateTagCount = async (tagName: string) => {

--- a/src/test/InjectMockProviders.tsx
+++ b/src/test/InjectMockProviders.tsx
@@ -1,0 +1,20 @@
+import { ComponentProps, ReactElement } from 'react';
+
+import InjectTestingRecoilState from './InjectTestingRecoilState';
+import ReactQueryWrapper from './ReactQueryWrapper';
+
+type Props = ComponentProps<typeof InjectTestingRecoilState>;
+
+function InjectMockProviders({ groupsCondition, children }: Props): ReactElement {
+  return (
+    <ReactQueryWrapper>
+      <InjectTestingRecoilState
+        groupsCondition={groupsCondition}
+      >
+        {children}
+      </InjectTestingRecoilState>
+    </ReactQueryWrapper>
+  );
+}
+
+export default InjectMockProviders;

--- a/src/test/InjectTestingRecoilState.tsx
+++ b/src/test/InjectTestingRecoilState.tsx
@@ -1,0 +1,33 @@
+import { ReactChild, ReactElement } from 'react';
+
+import { MutableSnapshot, RecoilRoot } from 'recoil';
+
+import { FilterGroupsCondition } from '@/models/group';
+import { groupsConditionState } from '@/recoil/group/atom';
+
+const initialGroupsCondition: FilterGroupsCondition = {
+  category: ['project', 'study'],
+  isFilterCompleted: false,
+};
+
+interface Props {
+  groupsCondition?: FilterGroupsCondition;
+  children: ReactChild;
+}
+
+function InjectTestingRecoilState({
+  groupsCondition = initialGroupsCondition,
+  children,
+}: Props): ReactElement {
+  return (
+    <RecoilRoot
+      initializeState={({ set }: MutableSnapshot): void => {
+        set(groupsConditionState, groupsCondition);
+      }}
+    >
+      {children}
+    </RecoilRoot>
+  );
+}
+
+export default InjectTestingRecoilState;

--- a/src/test/ReactQueryWrapper.tsx
+++ b/src/test/ReactQueryWrapper.tsx
@@ -1,0 +1,24 @@
+import { ReactChild, ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+interface Props {
+  children: ReactChild;
+}
+
+function ReactQueryWrapper({ children }: Props): ReactElement {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+
+export default ReactQueryWrapper;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
@@ -3239,6 +3246,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3293,6 +3305,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -4131,6 +4157,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 dicer@^0.3.0:
   version "0.3.1"
@@ -5302,6 +5333,11 @@ gtoken@^5.0.4:
     google-p12-pem "^3.0.3"
     jws "^4.0.0"
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE=
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -6318,6 +6354,11 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6800,6 +6841,14 @@ map-stream@~0.1.0:
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
   integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -6846,6 +6895,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -6937,6 +6991,13 @@ nano-css@^5.3.1:
     sourcemap-codec "^1.4.8"
     stacktrace-js "^2.0.2"
     stylis "^4.0.6"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoclone@^0.2.1:
   version "0.2.1"
@@ -7206,6 +7267,11 @@ object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -7717,6 +7783,15 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-query@^3.34.12:
+  version "3.34.12"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.12.tgz#dcaaf7b629f0868aae8afef9fb7692f6ea7643bf"
+  integrity sha512-flDdudQVH4CqE+kNYYYyo4g2Yjek3H/36G3b9bK5oe26jD5gFnx+PPwnq0gayq5z2dcSfr2z4+drvuyeZ3A5QQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-redux@^7.2.6:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
@@ -7809,6 +7884,13 @@ readdirp@~3.5.0:
   integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
   dependencies:
     picomatch "^2.2.1"
+
+recoil@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.6.1.tgz#6fdf1ba6cb20b5a2e54ec4abcbdaa287e8a03fa2"
+  integrity sha512-J7oT3LZl2vpyFClgSUpOQjpykz84VSX/NJE/PavAtR8n7Z+whEdVBPUtwc2TEWjONeL/lJmiac2XQ+qEOQA52Q==
+  dependencies:
+    hamt_plus "1.0.2"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -7903,6 +7985,11 @@ regjsparser@^0.7.0:
   dependencies:
     jsesc "~0.5.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 request-progress@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
@@ -7994,7 +8081,7 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -8915,6 +9002,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
1. tagsCount API React Query로 변경
2. getGroups API Ract Query로 변경
3. Main Page의 redux 걷어내기
4. Filter State를 Recoil에 관리
5. Install Recoil, React Query dependencies