### PR TITLE
[Improve] SignOut, SignUp, fetch user profile API를 React Query로 구현하라

### DIFF
--- a/src/hooks/api/auth/useFetchUserProfile.test.ts
+++ b/src/hooks/api/auth/useFetchUserProfile.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { getUserProfile } from '@/services/api/auth';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import FIXTURE_PROFILE from '../../../../fixtures/profile';
+
+import useFetchUserProfile from './useFetchUserProfile';
+
+jest.mock('@/services/api/auth');
+
+describe('useFetchUserProfile', () => {
+  const useFetchUserProfileHook = () => renderHook(() => useFetchUserProfile('userUid'), {
+    wrapper,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getUserProfile as jest.Mock).mockImplementation(() => (FIXTURE_PROFILE));
+  });
+
+  it('user에 대한 profile 정보를 반환해야만 한다', async () => {
+    const { result, waitFor } = useFetchUserProfileHook();
+
+    await waitFor(() => !!result.current.data);
+
+    expect(result.current.data).toEqual(FIXTURE_PROFILE);
+  });
+});

--- a/src/hooks/api/auth/useFetchUserProfile.ts
+++ b/src/hooks/api/auth/useFetchUserProfile.ts
@@ -1,0 +1,16 @@
+import { useQuery } from 'react-query';
+
+import { AuthError } from 'firebase/auth';
+
+import { Profile } from '@/models/auth';
+import { getUserProfile } from '@/services/api/auth';
+
+function useFetchUserProfile(userUid: string) {
+  const query = useQuery<Profile, AuthError>(['user', userUid], () => getUserProfile(userUid), {
+    enabled: !!userUid,
+  });
+
+  return query;
+}
+
+export default useFetchUserProfile;

--- a/src/hooks/api/auth/useSignOut.test.ts
+++ b/src/hooks/api/auth/useSignOut.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useRouter } from 'next/router';
+
+import { postSignOut } from '@/services/api/auth';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import useSignOut from './useSignOut';
+
+jest.mock('@/services/api/auth');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useSignOut', () => {
+  const replace = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (postSignOut as jest.Mock).mockResolvedValue(null);
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      replace,
+    }));
+  });
+
+  const useSignOutHook = () => renderHook(() => useSignOut(), {
+    wrapper,
+  });
+
+  it('replace가 "/"와 함께 호출해야만 한다', async () => {
+    const { result } = useSignOutHook();
+
+    await act(async () => {
+      await result.current.mutate();
+    });
+
+    expect(postSignOut).toBeCalled();
+    expect(result.current.isSuccess).toBeTruthy();
+    expect(replace).toBeCalledWith('/');
+  });
+});

--- a/src/hooks/api/auth/useSignOut.ts
+++ b/src/hooks/api/auth/useSignOut.ts
@@ -1,0 +1,20 @@
+import { useMutation } from 'react-query';
+
+import { AuthError } from 'firebase/auth';
+import { useRouter } from 'next/router';
+
+import { postSignOut } from '@/services/api/auth';
+
+function useSignOut() {
+  const { replace } = useRouter();
+
+  const mutation = useMutation<void, AuthError, void>(() => postSignOut(), {
+    onSuccess: () => {
+      replace('/');
+    },
+  });
+
+  return mutation;
+}
+
+export default useSignOut;

--- a/src/hooks/api/auth/useSignUp.test.ts
+++ b/src/hooks/api/auth/useSignUp.test.ts
@@ -1,0 +1,43 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useRouter } from 'next/router';
+
+import { postUserProfile } from '@/services/api/auth';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import PROFILE_FIXTURE from '../../../../fixtures/profile';
+
+import useSignUp from './useSignUp';
+
+jest.mock('@/services/api/auth');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useSignUp', () => {
+  const replace = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (postUserProfile as jest.Mock).mockResolvedValue(null);
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      replace,
+    }));
+  });
+
+  const useSignUpHook = () => renderHook(() => useSignUp(), {
+    wrapper,
+  });
+
+  it('replace가 "/"와 함께 호출해야만 한다', async () => {
+    const { result } = useSignUpHook();
+
+    await act(async () => {
+      await result.current.mutate(PROFILE_FIXTURE);
+    });
+
+    expect(postUserProfile).toBeCalledWith(PROFILE_FIXTURE);
+    expect(result.current.isSuccess).toBeTruthy();
+    expect(replace).toBeCalledWith('/');
+  });
+});

--- a/src/hooks/api/auth/useSignUp.ts
+++ b/src/hooks/api/auth/useSignUp.ts
@@ -1,0 +1,21 @@
+import { useMutation } from 'react-query';
+
+import { AuthError } from 'firebase/auth';
+import { useRouter } from 'next/router';
+
+import { Profile } from '@/models/auth';
+import { postUserProfile } from '@/services/api/auth';
+
+function useSignUp() {
+  const { replace } = useRouter();
+
+  const mutation = useMutation<void, AuthError, Profile>((profile) => postUserProfile(profile), {
+    onSuccess: () => {
+      replace('/');
+    },
+  });
+
+  return mutation;
+}
+
+export default useSignUp;


### PR DESCRIPTION
- SignOut, SignUp, fetch user profile API를 React Query로 구현