### PR TITLE
[Feature] 알람 페이지에서 사용자의 승인, 거절 알람 리스트를 볼 수 있게하라

### DIFF
--- a/fixtures/alarm.ts
+++ b/fixtures/alarm.ts
@@ -1,0 +1,15 @@
+import { Alarm } from '@/models/alarm';
+
+import group from './group';
+import profile from './profile';
+
+const alarm: Alarm = {
+  uid: '1',
+  group,
+  user: profile,
+  isViewed: false,
+  type: 'confirmed',
+  createdAt: '2021-11-11',
+};
+
+export default alarm;

--- a/src/components/alarm/AlarmItem.test.tsx
+++ b/src/components/alarm/AlarmItem.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+
+import ALARM_FIXTURE from '../../../fixtures/alarm';
+
+import AlarmItem from './AlarmItem';
+
+describe('AlarmItem', () => {
+  const renderAlarmItem = () => render((
+    <AlarmItem alarm={ALARM_FIXTURE} />
+  ));
+
+  it('알람에 대한 내용이 나타나야만 한다', () => {
+    const { container } = renderAlarmItem();
+
+    expect(container).toHaveTextContent(ALARM_FIXTURE.group.title);
+  });
+});

--- a/src/components/alarm/AlarmItem.tsx
+++ b/src/components/alarm/AlarmItem.tsx
@@ -1,0 +1,17 @@
+import React, { ReactElement } from 'react';
+
+import { Alarm } from '@/models/alarm';
+
+interface Props {
+  alarm: Alarm;
+}
+
+function AlarmItem({ alarm }: Props): ReactElement {
+  const { group } = alarm;
+
+  return (
+    <div>{group.title}</div>
+  );
+}
+
+export default AlarmItem;

--- a/src/components/alarm/Alarms.test.tsx
+++ b/src/components/alarm/Alarms.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+
+import ALARM_FIXTURE from '../../../fixtures/alarm';
+
+import Alarms from './Alarms';
+
+describe('Alarms', () => {
+  const renderAlarms = () => render((
+    <Alarms
+      isLoading={given.isLoading}
+      alarms={[ALARM_FIXTURE]}
+    />
+  ));
+
+  context('로딩중인 경우', () => {
+    given('isLoading', () => true);
+
+    it('"로딩중..." 문구가 나타나야만 한다', () => {
+      const { container } = renderAlarms();
+
+      expect(container).toHaveTextContent('로딩중...');
+    });
+  });
+
+  context('로딩중이 아닌 경우', () => {
+    given('isLoading', () => false);
+
+    it('알람에 대한 내용이 나타나야만 한다', () => {
+      const { container } = renderAlarms();
+
+      expect(container).toHaveTextContent(ALARM_FIXTURE.group.title);
+    });
+  });
+});

--- a/src/components/alarm/Alarms.tsx
+++ b/src/components/alarm/Alarms.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+
+import { Alarm } from '@/models/alarm';
+
+import AlarmItem from './AlarmItem';
+
+interface Props {
+  alarms: Alarm[];
+  isLoading: boolean;
+}
+
+function Alarms({ alarms, isLoading }: Props): ReactElement {
+  if (isLoading) {
+    return <>로딩중...</>;
+  }
+
+  return (
+    <>
+      {alarms.map((alarm) => (
+        <AlarmItem key={alarm.uid} alarm={alarm} />
+      ))}
+    </>
+  );
+}
+
+export default Alarms;

--- a/src/components/common/UserNavbar.tsx
+++ b/src/components/common/UserNavbar.tsx
@@ -1,10 +1,14 @@
 import React, {
   ReactElement, useCallback, useEffect, useRef, useState,
 } from 'react';
+import { Bell as AlarmIcon } from 'react-feather';
 import { useUnmount } from 'react-use';
 
 import styled from '@emotion/styled';
 import { User } from 'firebase/auth';
+import Link from 'next/link';
+
+import palette from '@/styles/palette';
 
 import Button from './Button';
 import DropDown from './DropDown';
@@ -53,6 +57,11 @@ function UserNavbar({ user, signOut }: Props): ReactElement {
       >
         팀 모집하기
       </Button>
+      <Link href="/alarm" passHref>
+        <a className="alarm-icon">
+          <AlarmIcon color={palette.accent6} />
+        </a>
+      </Link>
       <div className="profile-dropdown-wrapper" ref={userIconRef}>
         <ProfileImage
           src={user.photoURL}
@@ -74,9 +83,10 @@ export default UserNavbar;
 const UserNavbarWrapper = styled.div`
   display: flex;
   flex-direction: row;
+  align-items: center;
 
-  & > a:first-of-type {
-    margin-right: 24px;
+  .alarm-icon {
+    margin: 0 22px;
   }
 
   .profile-dropdown-wrapper {

--- a/src/containers/alarm/AlarmListContainer.test.tsx
+++ b/src/containers/alarm/AlarmListContainer.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+
+import useFetchAlarms from '@/hooks/api/alarm/useFetchAlarms';
+
+import ALARM_FIXTURE from '../../../fixtures/alarm';
+
+import AlarmListContainer from './AlarmListContainer';
+
+jest.mock('@/hooks/api/alarm/useFetchAlarms');
+
+describe('AlarmListContainer', () => {
+  beforeEach(() => {
+    (useFetchAlarms as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      data: [ALARM_FIXTURE],
+    }));
+  });
+
+  const renderAlarmListContainer = () => render((
+    <AlarmListContainer />
+  ));
+
+  it('알람 리스트에 대한 정보가 나타나야만 한다', () => {
+    const { container } = renderAlarmListContainer();
+
+    expect(useFetchAlarms).toBeCalled();
+    expect(container).toHaveTextContent(ALARM_FIXTURE.group.title);
+  });
+});

--- a/src/containers/alarm/AlarmListContainer.tsx
+++ b/src/containers/alarm/AlarmListContainer.tsx
@@ -1,0 +1,17 @@
+import React, { ReactElement } from 'react';
+
+import Alarms from '@/components/alarm/Alarms';
+import useFetchAlarms from '@/hooks/api/alarm/useFetchAlarms';
+
+function AlarmListContainer(): ReactElement {
+  const { data: alarms, isLoading } = useFetchAlarms();
+
+  return (
+    <Alarms
+      alarms={alarms}
+      isLoading={isLoading}
+    />
+  );
+}
+
+export default AlarmListContainer;

--- a/src/containers/applicants/ApplicationStatusHeaderContainer.test.tsx
+++ b/src/containers/applicants/ApplicationStatusHeaderContainer.test.tsx
@@ -94,13 +94,11 @@ describe('ApplicationStatusHeaderContainer', () => {
             numberConfirmApplicants: 1,
             alarmForms: [
               {
-                applicant: null,
                 groupId: GROUP_FIXTURE.groupId,
                 type: 'confirmed',
                 userUid: APPLICANT_FIXTURE.applicant.uid,
               },
               {
-                applicant: null,
                 groupId: GROUP_FIXTURE.groupId,
                 type: 'rejected',
                 userUid: APPLICANT_FIXTURE.applicant.uid,

--- a/src/containers/applicants/ApplicationStatusHeaderContainer.tsx
+++ b/src/containers/applicants/ApplicationStatusHeaderContainer.tsx
@@ -32,7 +32,6 @@ function ApplicationStatusHeaderContainer(): ReactElement {
     const alarmForms = applicants.map(({ applicant, isConfirm }) => ({
       userUid: applicant.uid,
       type: isConfirm ? 'confirmed' : 'rejected' as AlarmType,
-      applicant: null,
       groupId,
     }));
 

--- a/src/hooks/api/alarm/useFetchAlarms.test.ts
+++ b/src/hooks/api/alarm/useFetchAlarms.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { getUserAlarm } from '@/services/api/alarm';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import ALARM_FIXTURE from '../../../../fixtures/alarm';
+import PROFILE_FIXTURE from '../../../../fixtures/profile';
+import useGetUser from '../auth/useGetUser';
+
+import useFetchAlarms from './useFetchAlarms';
+
+jest.mock('@/services/api/alarm');
+jest.mock('../auth/useGetUser');
+
+describe('useFetchAlarms', () => {
+  const useFetchAlarmsHook = () => renderHook(() => useFetchAlarms(), { wrapper });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useGetUser as jest.Mock).mockImplementation(() => ({
+      data: PROFILE_FIXTURE,
+    }));
+    (getUserAlarm as jest.Mock).mockImplementation(() => (given.alarms));
+  });
+
+  context('useQuery반환값이 존재하지 않는 경우', () => {
+    given('alarms', () => null);
+
+    it('빈 배열을 반환해야만 한다', async () => {
+      const { result, waitFor } = useFetchAlarmsHook();
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(result.current.data).toEqual([]);
+    });
+  });
+
+  context('useQuery반환값이 존재하는 경우', () => {
+    given('alarms', () => [ALARM_FIXTURE]);
+
+    it('alarms에 대한 정보를 반환해야만 한다', async () => {
+      const { result, waitFor } = useFetchAlarmsHook();
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(result.current.data).toEqual([ALARM_FIXTURE]);
+    });
+  });
+});

--- a/src/hooks/api/alarm/useFetchAlarms.ts
+++ b/src/hooks/api/alarm/useFetchAlarms.ts
@@ -1,0 +1,32 @@
+import { useQuery } from 'react-query';
+
+import { FirestoreError } from 'firebase/firestore';
+
+import { Alarm } from '@/models/alarm';
+import { getUserAlarm } from '@/services/api/alarm';
+
+import useGetUser from '../auth/useGetUser';
+import useCatchErrorWithToast from '../useCatchErrorWithToast';
+
+function useFetchAlarms() {
+  const { data: user } = useGetUser();
+
+  const query = useQuery<Alarm[], FirestoreError>(['alarms'], () => getUserAlarm(user?.uid as string), {
+    enabled: !!user,
+  });
+
+  const { isError, error, data } = query;
+
+  useCatchErrorWithToast({
+    isError,
+    error,
+    defaultErrorMessage: '알람을 불러오는데 실패했어요!',
+  });
+
+  return {
+    ...query,
+    data: data ?? [],
+  };
+}
+
+export default useFetchAlarms;

--- a/src/hooks/api/group/useUpdateCompletedApply.test.ts
+++ b/src/hooks/api/group/useUpdateCompletedApply.test.ts
@@ -22,7 +22,6 @@ describe('useUpdateCompletedApply', () => {
         groupId: 'groupId',
         numberConfirmApplicants: 5,
         alarmForms: [{
-          applicant: null,
           groupId: 'groupId',
           type: 'confirmed',
           userUid: 'userUid',

--- a/src/hooks/api/group/useUpdateCompletedApply.ts
+++ b/src/hooks/api/group/useUpdateCompletedApply.ts
@@ -33,7 +33,7 @@ function useUpdateCompletedApply() {
         isCompleted: true,
       }));
 
-      queryClient.invalidateQueries('alarm');
+      queryClient.invalidateQueries('alarms');
     },
   });
 

--- a/src/models/alarm.ts
+++ b/src/models/alarm.ts
@@ -5,17 +5,23 @@ export type AlarmType = 'confirmed' | 'rejected' | 'applied';
 
 export interface Alarm {
   uid: string;
-  userUid: string;
+  user: Profile;
   group: Group;
   type: AlarmType;
-  applicant: Profile | null;
   isViewed: boolean;
   createdAt: string;
 }
 
 export interface AlarmForm {
   userUid: string;
-  applicant: Profile | null;
   groupId: string;
   type: AlarmType;
+}
+
+export interface AlarmResponse {
+  userUid: string;
+  groupId: string;
+  type: AlarmType;
+  isViewed: boolean;
+  createdAt: string;
 }

--- a/src/pages/alarm.page.tsx
+++ b/src/pages/alarm.page.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement } from 'react';
+
+import { GetServerSideProps } from 'next';
+
+import AlarmListContainer from '@/containers/alarm/AlarmListContainer';
+import HeaderContainer from '@/containers/common/HeaderContainer';
+import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
+import { DetailLayout } from '@/styles/Layout';
+
+export const getServerSideProps: GetServerSideProps = authenticatedServerSideProps;
+
+function AlarmPage(): ReactElement {
+  return (
+    <>
+      <HeaderContainer />
+      <DetailLayout>
+        <AlarmListContainer />
+      </DetailLayout>
+    </>
+  );
+}
+
+export default AlarmPage;

--- a/src/pages/alarm.test.tsx
+++ b/src/pages/alarm.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react';
+
+import useFetchAlarms from '@/hooks/api/alarm/useFetchAlarms';
+import useGetUser from '@/hooks/api/auth/useGetUser';
+import useSignOut from '@/hooks/api/auth/useSignOut';
+import InjectTestingRecoilState from '@/test/InjectTestingRecoilState';
+
+import ALARM_FIXTURE from '../../fixtures/alarm';
+import PROFILE_FIXTURE from '../../fixtures/profile';
+
+import AlarmPage from './alarm.page';
+
+jest.mock('@/hooks/api/alarm/useFetchAlarms');
+jest.mock('@/hooks/api/auth/useGetUser');
+jest.mock('@/hooks/api/auth/useSignOut');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockImplementation(() => ({
+    pathName: '/alarm',
+  })),
+}));
+
+describe('AlarmPage', () => {
+  beforeEach(() => {
+    (useGetUser as jest.Mock).mockImplementation(() => ({
+      data: PROFILE_FIXTURE,
+    }));
+    (useSignOut as jest.Mock).mockImplementation(() => ({
+      mutate: jest.fn(),
+    }));
+    (useFetchAlarms as jest.Mock).mockImplementation(() => ({
+      data: [ALARM_FIXTURE],
+    }));
+  });
+
+  const renderAlarmPage = () => render((
+    <InjectTestingRecoilState>
+      <AlarmPage />
+    </InjectTestingRecoilState>
+  ));
+
+  it('알람에 대한 정보가 나타나야만 한다', () => {
+    const { container } = renderAlarmPage();
+
+    expect(container).toHaveTextContent(ALARM_FIXTURE.group.title);
+  });
+});

--- a/src/services/api/alarm.test.ts
+++ b/src/services/api/alarm.test.ts
@@ -5,7 +5,7 @@ import {
 import { AlarmForm } from '@/models/alarm';
 import { formatAlarm } from '@/utils/firestore';
 
-import PROFILE_FIXTURE from '../../../fixtures/profile';
+import ALARM_FIXTURE from '../../../fixtures/alarm';
 import { collectionRef } from '../firebase';
 
 import { getUserAlarm, postAddAlarm } from './alarm';
@@ -26,7 +26,6 @@ describe('alarm API', () => {
       groupId: 'groupId',
       type: 'applied',
       userUid: 'userUid',
-      applicant: null,
     };
 
     beforeEach(() => {
@@ -54,15 +53,15 @@ describe('alarm API', () => {
   describe('getUserAlarm', () => {
     beforeEach(() => {
       (getDocs as jest.Mock).mockImplementationOnce(() => ({
-        docs: [PROFILE_FIXTURE],
+        docs: [ALARM_FIXTURE],
       }));
-      (formatAlarm as jest.Mock).mockReturnValueOnce(PROFILE_FIXTURE);
+      (formatAlarm as jest.Mock).mockResolvedValue(ALARM_FIXTURE);
     });
 
     it('알람 리스트가 반환되어야만 한다', async () => {
-      const response = await getUserAlarm('groupId');
+      const response = await getUserAlarm('userUid');
 
-      expect(response).toEqual([PROFILE_FIXTURE]);
+      expect(response).toEqual([ALARM_FIXTURE]);
       expect(getDocs).toBeCalledTimes(1);
     });
   });

--- a/src/services/api/alarm.ts
+++ b/src/services/api/alarm.ts
@@ -2,7 +2,7 @@ import {
   addDoc, getDocs, orderBy, query, serverTimestamp, where,
 } from 'firebase/firestore';
 
-import { Alarm, AlarmForm } from '@/models/alarm';
+import { AlarmForm } from '@/models/alarm';
 import { formatAlarm } from '@/utils/firestore';
 
 import { collectionRef } from '../firebase';
@@ -28,5 +28,7 @@ export const getUserAlarm = async (userUid: string) => {
 
   const response = await getDocs(getQuery);
 
-  return response.docs.map(formatAlarm) as Alarm[];
+  const alarm = Promise.all([...response.docs.map(formatAlarm)]);
+
+  return alarm;
 };

--- a/src/services/api/group.ts
+++ b/src/services/api/group.ts
@@ -13,6 +13,7 @@ import { Profile } from '@/models/auth';
 import {
   FilterGroupsCondition, Group, WriteFields,
 } from '@/models/group';
+// eslint-disable-next-line import/no-cycle
 import { formatGroup, timestampToString } from '@/utils/firestore';
 import { isRecruiting } from '@/utils/utils';
 

--- a/src/utils/firestore.test.ts
+++ b/src/utils/firestore.test.ts
@@ -1,9 +1,18 @@
 import { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
 
+import { getUserProfile } from '@/services/api/auth';
+import { getGroupDetail } from '@/services/api/group';
+
+import GROUP_FIXTURE from '../../fixtures/group';
+import PROFILE_FIXTURE from '../../fixtures/profile';
+
 import {
   formatAlarm,
   formatApplicant, formatComment, formatGroup, timestampToString,
 } from './firestore';
+
+jest.mock('@/services/api/group');
+jest.mock('@/services/api/auth');
 
 describe('timestampToString', () => {
   const timestamp = {
@@ -92,6 +101,11 @@ describe('formatApplicant', () => {
 });
 
 describe('formatAlarm', () => {
+  beforeEach(() => {
+    (getGroupDetail as jest.Mock).mockImplementation(() => (GROUP_FIXTURE));
+    (getUserProfile as jest.Mock).mockImplementation(() => (PROFILE_FIXTURE));
+  });
+
   const nowString = new Date().toString();
 
   const date = {
@@ -101,16 +115,24 @@ describe('formatAlarm', () => {
   const settings = {
     id: '1',
     data: () => ({
+      groupId: '1',
+      userUid: '2',
+      isViewed: false,
+      type: 'confirmed',
       createdAt: date,
     }),
   } as unknown as QueryDocumentSnapshot<DocumentData>;
 
-  it('포매팅된 알람 정보가 반환되어야만 한다', () => {
-    const result = formatAlarm(settings);
+  it('포매팅된 알람 정보가 반환되어야만 한다', async () => {
+    const result = await formatAlarm(settings);
 
     expect(result).toEqual({
       uid: '1',
       createdAt: nowString,
+      isViewed: false,
+      type: 'confirmed',
+      group: GROUP_FIXTURE,
+      user: PROFILE_FIXTURE,
     });
   });
 });

--- a/src/utils/firestore.ts
+++ b/src/utils/firestore.ts
@@ -1,5 +1,12 @@
 import { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
 
+import { Alarm, AlarmResponse } from '@/models/alarm';
+import { Profile } from '@/models/auth';
+import { Group } from '@/models/group';
+import { getUserProfile } from '@/services/api/auth';
+// eslint-disable-next-line import/no-cycle
+import { getGroupDetail } from '@/services/api/group';
+
 export const timestampToString = (timestamp: any) => timestamp.toDate().toString();
 
 export const formatGroup = (group: QueryDocumentSnapshot<DocumentData>) => {
@@ -32,12 +39,20 @@ export const formatApplicant = (applicant: QueryDocumentSnapshot<DocumentData>) 
   };
 };
 
-export const formatAlarm = (alarm: QueryDocumentSnapshot<DocumentData>) => {
-  const { createdAt } = alarm.data();
+export const formatAlarm = async (alarm: QueryDocumentSnapshot<DocumentData>) => {
+  const {
+    createdAt, groupId, userUid, isViewed, type,
+  } = alarm.data() as AlarmResponse;
+
+  const group = await getGroupDetail(groupId) as Group;
+  const user = await getUserProfile(userUid) as Profile;
 
   return {
-    ...alarm.data(),
     uid: alarm.id,
+    user,
+    group,
+    type,
+    isViewed,
     createdAt: timestampToString(createdAt),
-  };
+  } as Alarm;
 };


### PR DESCRIPTION
- 알람 페이지에서 사용자의 승인, 거절 알람 리스트를 볼 수 있다
- 사용자가 신청한 스터디 및 프로젝트에 대해서 상태가 승인 또는 거절 상태를 알 수 있다.
- 알람 `/alarm` 페이지 생성
- 헤더에 알람 아이콘 추가, 클릭시 알람 페이지로 이동