### PR TITLE
[Fix] 디자인 피드백을 반영하라

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -22,7 +22,7 @@ interface StyledButtonProps {
 }
 
 function Button({
-  color = 'outlined', size = 'medium', href, children, ...rest
+  color = 'outlined', size = 'medium', href, children, type = 'button', ...rest
 }: PropsWithChildren<Props>): ReactElement {
   const htmlProps = rest as any;
 
@@ -44,6 +44,7 @@ function Button({
     <StyledButton
       color={color}
       size={size}
+      type={type}
       {...htmlProps}
     >
       {children}

--- a/src/components/detail/ApplicantStatusButton.test.tsx
+++ b/src/components/detail/ApplicantStatusButton.test.tsx
@@ -2,10 +2,14 @@ import {
   act, fireEvent, render, screen,
 } from '@testing-library/react';
 
+import useFetchApplicants from '@/hooks/api/applicant/useFetchApplicants';
+
 import APPLICANT_FIXTURE from '../../../fixtures/applicant';
 import PROFILE_FIXTURE from '../../../fixtures/profile';
 
 import ApplicantStatusButton from './ApplicantStatusButton';
+
+jest.mock('@/hooks/api/applicant/useFetchApplicants');
 
 describe('ApplicantStatusButton', () => {
   const handleApply = jest.fn();
@@ -14,6 +18,13 @@ describe('ApplicantStatusButton', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    (useFetchApplicants as jest.Mock).mockImplementation(() => ({
+      data: [{
+        ...APPLICANT_FIXTURE,
+        isConfirm: true,
+      }],
+    }));
   });
 
   const renderApplicantStatusButton = () => render((
@@ -153,10 +164,25 @@ describe('ApplicantStatusButton', () => {
       isConfirm: true,
     }));
 
-    it('"팀원 보기"버튼이 보여야만 한다', () => {
-      const { container } = renderApplicantStatusButton();
+    describe('"팀원 보기" 버튼을 클릭한다', () => {
+      it('팀원보기 모달창이 나타나야만 한다', () => {
+        renderApplicantStatusButton();
 
-      expect(container).toHaveTextContent('팀원 보기');
+        fireEvent.click(screen.getByText('팀원 보기'));
+
+        expect(screen.getByTestId('modal-box')).toBeInTheDocument();
+      });
+    });
+
+    describe('팀원보기 모달창에서 닫기 버튼을 클릭한다', () => {
+      it('모달창이 사라져야만 한다', () => {
+        const { container } = renderApplicantStatusButton();
+
+        fireEvent.click(screen.getByText('팀원 보기'));
+        fireEvent.click(screen.getByTestId('close-icon'));
+
+        expect(container).not.toHaveTextContent('팀원 1명');
+      });
     });
   });
 });

--- a/src/components/detail/ApplicantStatusButton.tsx
+++ b/src/components/detail/ApplicantStatusButton.tsx
@@ -5,6 +5,7 @@ import { Applicant, ApplicantForm } from '@/models/group';
 
 import Button from '../common/Button';
 
+import ApplicantsViewModal from './modal/ApplicantsViewModal';
 import AskApplyCancelModal from './modal/AskApplyCancelModal';
 import ApplyFormModal from './ApplyFormModal';
 
@@ -23,6 +24,7 @@ function ApplicantStatusButton({
 }: Props): ReactElement | null {
   const [isVisibleApplyModal, setIsVisibleApplyModal] = useState<boolean>(false);
   const [isVisibleCancelModal, setIsVisibleCancelModal] = useState<boolean>(false);
+  const [isVisibleApplicantsModal, setIsVisibleApplicantsModal] = useState<boolean>(false);
 
   const handleSubmit = (applyFields: ApplicantForm) => {
     onApply(applyFields);
@@ -40,9 +42,15 @@ function ApplicantStatusButton({
 
   if (isCompleted && applicant?.isConfirm) {
     return (
-      <Button color="primary">
-        팀원 보기
-      </Button>
+      <>
+        <Button color="primary" onClick={() => setIsVisibleApplicantsModal(true)}>
+          팀원 보기
+        </Button>
+        <ApplicantsViewModal
+          isVisible={isVisibleApplicantsModal}
+          onClose={() => setIsVisibleApplicantsModal(false)}
+        />
+      </>
     );
   }
 

--- a/src/components/detail/CommentForm.test.tsx
+++ b/src/components/detail/CommentForm.test.tsx
@@ -6,18 +6,15 @@ import CommentForm from './CommentForm';
 
 describe('CommentForm', () => {
   const handleSubmit = jest.fn();
-  const handleVisible = jest.fn();
 
   beforeEach(() => {
     handleSubmit.mockClear();
-    handleVisible.mockClear();
   });
 
   const renderCommentForm = () => render((
     <CommentForm
       user={given.user}
       onSubmit={handleSubmit}
-      onVisible={handleVisible}
     />
   ));
 
@@ -86,14 +83,10 @@ describe('CommentForm', () => {
   context('사용자가 로그인하지 않은 경우', () => {
     given('user', () => null);
 
-    describe('"시작하기" 버튼을 클릭한다', () => {
-      it('클릭 이벤트가 호출되어야만 한다', () => {
-        renderCommentForm();
+    it('"댓글 남기기" 버튼이 보이지 않는다', () => {
+      const { container } = renderCommentForm();
 
-        fireEvent.click(screen.getByText('시작하기'));
-
-        expect(handleVisible).toBeCalledTimes(1);
-      });
+      expect(container).not.toHaveTextContent('댓글 남기기');
     });
   });
 });

--- a/src/components/detail/CommentForm.tsx
+++ b/src/components/detail/CommentForm.tsx
@@ -11,10 +11,9 @@ import Textarea from '../common/Textarea';
 interface Props {
   onSubmit: (commentForm: CommentFields) => void;
   user: Profile | null;
-  onVisible: () => void;
 }
 
-function CommentForm({ onSubmit, onVisible, user }: Props): ReactElement {
+function CommentForm({ onSubmit, user }: Props): ReactElement {
   const [content, setContent] = useState<string>('');
 
   const textareaPlaceholderText = user ? '댓글을 입력하세요' : '댓글을 남기려면 로그인이 필요합니다.';
@@ -36,13 +35,9 @@ function CommentForm({ onSubmit, onVisible, user }: Props): ReactElement {
         onChange={handleChange}
         disabled={!user}
       />
-      {user ? (
+      {user && (
         <Button color="primary" onClick={() => handleSubmit(user)} disabled={!content.trim()}>
           댓글 남기기
-        </Button>
-      ) : (
-        <Button color="success" onClick={onVisible}>
-          시작하기
         </Button>
       )}
     </CommentFormWrapper>
@@ -55,7 +50,7 @@ const CommentFormWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  margin-bottom: 120px;
+  margin-bottom: 30px;
 
   textarea {
     margin-bottom: 18px;

--- a/src/components/detail/CommentView.test.tsx
+++ b/src/components/detail/CommentView.test.tsx
@@ -20,38 +20,10 @@ describe('CommentView', () => {
     given('user', () => PROFILE_FIXTURE);
 
     describe('삭제 버튼을 클릭한다', () => {
-      it('댓글 삭제 확인 모달창이 나타나야만 한다', () => {
-        const { container } = renderCommentView();
-
-        fireEvent.click(screen.getByText('삭제'));
-
-        expect(container).toHaveTextContent(/삭제하기/);
-      });
-    });
-
-    describe('모달창의 닫기 버튼을 클릭한다', () => {
-      it('모달창이 사라저야만 한다', () => {
-        const { container } = renderCommentView();
-
-        fireEvent.click(screen.getByText('삭제'));
-
-        expect(container).toHaveTextContent(/삭제하기/);
-
-        fireEvent.click(screen.getByText('닫기'));
-
-        expect(container).not.toHaveTextContent(/삭제하기/);
-      });
-    });
-
-    describe('댓글 삭제 확인 모달창에서 "삭제하기" 버튼을 클릭한다', () => {
-      it('삭제 클릭 이벤트가 호출되어야만 한다', () => {
+      it('클릭 이벤트가 발생해야만 한다', () => {
         renderCommentView();
 
         fireEvent.click(screen.getByText('삭제'));
-
-        screen.getAllByText(/삭제하기/).forEach((button) => {
-          fireEvent.click(button);
-        });
 
         expect(handleRemove).toBeCalledWith(COMMENT_FIXTURE.commentId);
       });

--- a/src/components/detail/CommentView.tsx
+++ b/src/components/detail/CommentView.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactElement, useState } from 'react';
+import React, { memo, ReactElement } from 'react';
 
 import styled from '@emotion/styled';
 import dayjs from 'dayjs';
@@ -15,8 +15,6 @@ import 'dayjs/locale/ko';
 
 import ProfileImage from '../common/ProfileImage';
 
-import AskDeleteCommentModal from './modal/AskDeleteCommentModal';
-
 dayjs.locale('ko');
 dayjs.extend(relativeTime);
 
@@ -27,7 +25,6 @@ interface Props {
 }
 
 function CommentView({ comment, user, onRemove }: Props): ReactElement {
-  const [isVisibleModal, setIsVisible] = useState<boolean>(false);
   const {
     writer, content, createdAt, commentId,
   } = comment;
@@ -44,19 +41,12 @@ function CommentView({ comment, user, onRemove }: Props): ReactElement {
             <div className="recruit-date">{dayjs(createdAt).fromNow()}</div>
           </CommentState>
           {isWriter && (
-            <>
-              <RemoveCommentButton
-                type="button"
-                onClick={() => setIsVisible(true)}
-              >
-                삭제
-              </RemoveCommentButton>
-              <AskDeleteCommentModal
-                isVisible={isVisibleModal}
-                onClose={() => setIsVisible(false)}
-                onConfirm={() => onRemove(commentId)}
-              />
-            </>
+            <RemoveCommentButton
+              type="button"
+              onClick={() => onRemove(commentId)}
+            >
+              삭제
+            </RemoveCommentButton>
           )}
         </CommentStatus>
         <CommentContent dangerouslySetInnerHTML={{ __html: content }} />

--- a/src/components/detail/CommentsView.test.tsx
+++ b/src/components/detail/CommentsView.test.tsx
@@ -36,9 +36,6 @@ describe('CommentsView', () => {
         renderCommentsView();
 
         fireEvent.click(screen.getByText('삭제'));
-        screen.getAllByText(/삭제하기/).forEach((button) => {
-          fireEvent.click(button);
-        });
 
         expect(handleRemove).toBeCalledWith(COMMENT_FIXTURE.commentId);
       });

--- a/src/components/detail/CommentsView.tsx
+++ b/src/components/detail/CommentsView.tsx
@@ -23,7 +23,6 @@ function CommentsView({
 
   return (
     <CommentsViewWrapper>
-      <h4>{`댓글 ${comments.length}`}</h4>
       {comments.map((comment) => (
         <CommentView
           key={comment.commentId}
@@ -39,11 +38,8 @@ function CommentsView({
 export default memo(CommentsView);
 
 const CommentsViewWrapper = styled.div`
-  h4 {
-    font-weight: 600;
-  }
-
   & > div:last-of-type {
     border-bottom: none;
+    margin-bottom: 50px;
   }
 `;

--- a/src/containers/detail/CommentsContainer.test.tsx
+++ b/src/containers/detail/CommentsContainer.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { useSetRecoilState } from 'recoil';
 
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useGetUser from '@/hooks/api/auth/useGetUser';
@@ -23,11 +22,9 @@ jest.mock('next/router', () => ({
     },
   })),
 }));
-jest.mock('recoil');
 
 describe('CommentsContainer', () => {
   const mutate = jest.fn();
-  const handleSetSignInModalVisible = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -48,7 +45,6 @@ describe('CommentsContainer', () => {
       data: [COMMENT_FIXTURE],
       isLoading: false,
     }));
-    (useSetRecoilState as jest.Mock).mockImplementation(() => handleSetSignInModalVisible);
   });
 
   const renderCommentsContainer = () => render((
@@ -84,32 +80,15 @@ describe('CommentsContainer', () => {
       });
 
       describe('삭제 모달창의 "삭제하기" 버튼을 클릭한다', () => {
-        it('dispatch 액션이 호출되어야만 한다', () => {
+        it('remove mutate 액션이 호출되어야만 한다', () => {
           renderCommentsContainer();
 
           fireEvent.click(screen.getByText('삭제'));
-          screen.getAllByText(/삭제하기/).forEach((button) => {
-            fireEvent.click(button);
-          });
 
           expect(mutate).toBeCalledWith({
             commentId: COMMENT_FIXTURE.commentId,
             groupId: '1',
           });
-        });
-      });
-    });
-
-    context('사용자가 비로그인 상태인 경우', () => {
-      given('user', () => (null));
-
-      describe('"시작하기" 버튼을 클릭한다', () => {
-        it('handleSetSignInModalVisible이 true와 함께 호출되어야만 한다', () => {
-          renderCommentsContainer();
-
-          fireEvent.click(screen.getByText('시작하기'));
-
-          expect(handleSetSignInModalVisible).toBeCalledWith(true);
         });
       });
     });

--- a/src/containers/detail/CommentsContainer.tsx
+++ b/src/containers/detail/CommentsContainer.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback } from 'react';
 
+import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useSetRecoilState } from 'recoil';
 
 import CommentForm from '@/components/detail/CommentForm';
 import CommentsView from '@/components/detail/CommentsView';
@@ -12,19 +12,16 @@ import useDeleteComment from '@/hooks/api/comment/useDeleteComment';
 import useFetchComments from '@/hooks/api/comment/useFetchComments';
 import { GroupQuery } from '@/models';
 import { CommentFields } from '@/models/group';
-import { signInModalVisibleState } from '@/recoil/modal/atom';
+import { h4Font } from '@/styles/fontStyles';
 
 function CommentsContainer(): ReactElement {
   const router = useRouter();
   const { id: groupId } = router.query as GroupQuery;
   const { data: user } = useGetUser();
   const { data: profile } = useFetchUserProfile();
-  const setSignInModalVisible = useSetRecoilState(signInModalVisibleState);
   const { data: comments, isLoading } = useFetchComments();
   const { mutate: addCommentMutate } = useAddComment();
   const { mutate: deleteCommentMutate } = useDeleteComment();
-
-  const onVisibleSignInModal = () => setSignInModalVisible(true);
 
   const onSubmit = useCallback((commentForm: CommentFields) => addCommentMutate({
     ...commentForm,
@@ -37,19 +34,25 @@ function CommentsContainer(): ReactElement {
 
   return (
     <>
+      <CommentCount>{`댓글 ${comments.length}`}</CommentCount>
+      <CommentForm
+        user={profile}
+        onSubmit={onSubmit}
+      />
       <CommentsView
         user={user}
         comments={comments}
         isLoading={isLoading}
         onRemove={onRemoveComment}
       />
-      <CommentForm
-        user={profile}
-        onSubmit={onSubmit}
-        onVisible={onVisibleSignInModal}
-      />
     </>
   );
 }
 
 export default CommentsContainer;
+
+const CommentCount = styled.h4`
+  ${h4Font(true)}
+  margin-top: 24px;
+  margin-bottom: 16px;
+`;

--- a/src/hooks/__mocks__/useRenderSuccessToast.ts
+++ b/src/hooks/__mocks__/useRenderSuccessToast.ts
@@ -1,0 +1,3 @@
+const useRenderSuccessToast = jest.fn();
+
+export default useRenderSuccessToast;

--- a/src/hooks/api/comment/useDeleteComment.test.ts
+++ b/src/hooks/api/comment/useDeleteComment.test.ts
@@ -8,6 +8,7 @@ import FIXTURE_COMMENT from '../../../../fixtures/comment';
 import useDeleteComment, { filteredRemoveComment } from './useDeleteComment';
 
 jest.mock('@/services/api/comment');
+jest.mock('@/hooks/useRenderSuccessToast');
 
 describe('useDeleteComment', () => {
   const useDeleteCommentHook = () => renderHook(() => useDeleteComment(), { wrapper });

--- a/src/hooks/api/comment/useDeleteComment.ts
+++ b/src/hooks/api/comment/useDeleteComment.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from 'react-query';
 
 import { FirestoreError } from 'firebase/firestore';
 
+import useRenderSuccessToast from '@/hooks/useRenderSuccessToast';
 import { Comment } from '@/models/group';
 import { deleteGroupComment } from '@/services/api/comment';
 
@@ -23,7 +24,9 @@ function useDeleteComment() {
     },
   });
 
-  const { isError, error } = mutation;
+  const { isError, error, isSuccess } = mutation;
+
+  useRenderSuccessToast(isSuccess, '댓글을 삭제했어요.');
 
   useCatchErrorWithToast({
     isError,

--- a/src/hooks/useRenderSuccessToast.test.ts
+++ b/src/hooks/useRenderSuccessToast.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { successToast } from '@/utils/toast';
+
+import useRenderSuccessToast from './useRenderSuccessToast';
+
+jest.mock('@/utils/toast');
+
+describe('useRenderSuccessToast', () => {
+  const message = '성공이에요!';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const useRenderSuccessToastHook = () => renderHook(() => useRenderSuccessToast(
+    given.isSuccess,
+    message,
+  ));
+
+  context('isSuccess가 true인 경우', () => {
+    given('isSuccess', () => true);
+
+    it('"successToast"가 메시지와 함꼐 호출되어야만 한다', () => {
+      useRenderSuccessToastHook();
+
+      expect(successToast).toBeCalledWith(message);
+    });
+  });
+
+  context('isSuccess가 false인 경우', () => {
+    given('isSuccess', () => false);
+
+    it('"successToast"가 호출되지 않아야만 한다', () => {
+      useRenderSuccessToastHook();
+
+      expect(successToast).not.toBeCalled();
+    });
+  });
+});

--- a/src/hooks/useRenderSuccessToast.ts
+++ b/src/hooks/useRenderSuccessToast.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+import { successToast } from '@/utils/toast';
+
+function useRenderSuccessToast(isSuccess: boolean, message: string) {
+  useEffect(() => {
+    if (isSuccess) {
+      successToast(message);
+    }
+  }, [isSuccess]);
+}
+
+export default useRenderSuccessToast;


### PR DESCRIPTION
- 댓글 입력 폼을 댓글리스트 상단으로 이동
- 비로그인시 댓글 남기기 버튼 삭제
- 모집 완료 후 팀원도 팀원 보기 가능
- 삭제 시 삭제 confirm 모달창 안띄우기로 변경
- 삭제 시 success toast message 추가