### PR TITLE
[Improve] 처음 로그인하는 사용자에 대한 플로우 수정하라

### DIFF
--- a/src/components/common/Core.test.tsx
+++ b/src/components/common/Core.test.tsx
@@ -6,6 +6,8 @@ import Core from './Core';
 
 jest.mock('@/hooks/api/auth/useGetUserToken');
 jest.mock('@/hooks/api/auth/useRefreshToken');
+jest.mock('@/hooks/api/auth/useAuthRedirectResult');
+jest.mock('@/hooks/api/auth/useCheckSignUp');
 jest.mock('next/router', () => ({
   useRouter: jest.fn().mockImplementation(() => ({
     pathName: '/',

--- a/src/components/common/Core.tsx
+++ b/src/components/common/Core.tsx
@@ -3,6 +3,8 @@ import { Bounce } from 'react-toastify';
 
 import NextNProgress from 'nextjs-progressbar';
 
+import useAuthRedirectResult from '@/hooks/api/auth/useAuthRedirectResult';
+import useCheckSignUp from '@/hooks/api/auth/useCheckSignUp';
 import useGetUserToken from '@/hooks/api/auth/useGetUserToken';
 import GlobalStyles from '@/styles/GlobalStyles';
 import palette from '@/styles/palette';
@@ -17,6 +19,8 @@ import 'react-toastify/dist/ReactToastify.css';
 function Core(): ReactElement {
   useGetUserToken();
   useRefreshToken();
+  useAuthRedirectResult();
+  useCheckSignUp();
 
   return (
     <>

--- a/src/containers/auth/SignUpContainer.tsx
+++ b/src/containers/auth/SignUpContainer.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useCallback } from 'react';
+import { useEffectOnce, useLocalStorage } from 'react-use';
 
 import styled from '@emotion/styled';
 import { User } from 'firebase/auth';
@@ -15,8 +16,10 @@ import palette from '@/styles/palette';
 function SignUpContainer(): ReactElement {
   const { data: profile } = useFetchUserProfile();
   const { data: user } = useGetUser();
-
   const { mutate } = useSignUp();
+  const [, setIsSignUp] = useLocalStorage('isSignUp', false, {
+    raw: true,
+  });
 
   const onSubmit = useCallback((formData: SignUpAdditionalForm) => {
     const { email, uid, photoURL } = user as User;
@@ -36,6 +39,8 @@ function SignUpContainer(): ReactElement {
   if (!user) {
     return <div>로그인부터 진행해주세요!</div>;
   }
+
+  useEffectOnce(() => setIsSignUp(false));
 
   return (
     <SignUpFormLayout>

--- a/src/hooks/api/auth/useAuthRedirectResult.test.ts
+++ b/src/hooks/api/auth/useAuthRedirectResult.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRouter } from 'next/router';
+
+import { getAuthRedirectResult } from '@/services/api/auth';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import FIXTURE_PROFILE from '../../../../fixtures/profile';
+
+import useAuthRedirectResult from './useAuthRedirectResult';
+import useFetchUserProfile from './useFetchUserProfile';
+
+jest.mock('@/services/api/auth');
+jest.mock('./useFetchUserProfile');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useAuthRedirectResult', () => {
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useFetchUserProfile as jest.Mock).mockImplementation(() => ({
+      data: given.profile,
+      isSuccess: true,
+    }));
+    (getAuthRedirectResult as jest.Mock).mockImplementation(() => FIXTURE_PROFILE);
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      push: mockPush,
+    }));
+  });
+
+  const useAuthRedirectResultHook = () => renderHook(() => useAuthRedirectResult(), {
+    wrapper,
+  });
+
+  context('isSuccess가 true이고 user 정보는 존재하지만, profile 정보가 존재하지 않는 경우', () => {
+    given('profile', () => null);
+
+    it('"/signup"과 함께 router.push가 호출되어야만 한다', async () => {
+      const { result, waitFor } = useAuthRedirectResultHook();
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(getAuthRedirectResult).toBeCalled();
+      expect(result.current.isSuccess).toBeTruthy();
+      expect(mockPush).toBeCalledWith('/signup');
+    });
+  });
+
+  context('isSuccess가 false이거나 user 정보가 존재하지 않거나, profile 정보가 존재하는 경우', () => {
+    given('profile', () => FIXTURE_PROFILE);
+
+    it('router.push가 호출되지 않아야만 한다', async () => {
+      const { result, waitFor } = useAuthRedirectResultHook();
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(result.current.isSuccess).toBeTruthy();
+      expect(mockPush).not.toBeCalled();
+    });
+  });
+});

--- a/src/hooks/api/auth/useAuthRedirectResult.ts
+++ b/src/hooks/api/auth/useAuthRedirectResult.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+
+import { AuthError, User } from 'firebase/auth';
+import { useRouter } from 'next/router';
+
+import { getAuthRedirectResult } from '@/services/api/auth';
+
+import useFetchUserProfile from './useFetchUserProfile';
+
+function useAuthRedirectResult() {
+  const { data: profile, isSuccess } = useFetchUserProfile();
+  const router = useRouter();
+
+  const query = useQuery<User | undefined, AuthError>(['authRedirectResult'], () => getAuthRedirectResult(), {
+    enabled: false,
+  });
+
+  useEffect(() => {
+    query.refetch();
+  }, []);
+
+  useEffect(() => {
+    if (query.isSuccess && query.data && isSuccess && !profile) {
+      router.push('/signup');
+    }
+  }, [query.data, query.isSuccess, isSuccess, profile]);
+
+  return query;
+}
+
+export default useAuthRedirectResult;

--- a/src/hooks/api/auth/useCheckSignUp.test.ts
+++ b/src/hooks/api/auth/useCheckSignUp.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRouter } from 'next/router';
+
+import { postSignOut } from '@/services/api/auth';
+import { loadItem, removeItem } from '@/services/storage';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import useCheckSignUp from './useCheckSignUp';
+
+jest.mock('@/services/api/auth');
+jest.mock('@/services/storage');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useCheckSignUp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (postSignOut as jest.Mock).mockResolvedValue(null);
+    (loadItem as jest.Mock).mockImplementation(() => false);
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      pathname: given.pathname,
+    }));
+  });
+
+  const useCheckSignUpHook = () => renderHook(() => useCheckSignUp(), {
+    wrapper,
+  });
+
+  context('pathname이 /signup이 아니고 isSignUp이 false인 경우', () => {
+    given('pathname', () => '/');
+
+    it('postSignOut이 호출되어야만 한다', async () => {
+      const { result, waitFor } = useCheckSignUpHook();
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(postSignOut).toBeCalled();
+      expect(result.current.isSuccess).toBeTruthy();
+      expect(removeItem).toBeCalledWith('isSignUp');
+    });
+  });
+
+  context('pathname이 /signup이거나 isSignUp이 false가 아닌 경우', () => {
+    given('pathname', () => '/signup');
+
+    it('postSignOut는 호출되지 않아야만 한다', async () => {
+      useCheckSignUpHook();
+
+      expect(postSignOut).not.toBeCalled();
+      expect(removeItem).not.toBeCalled();
+    });
+  });
+});

--- a/src/hooks/api/auth/useSignUp.ts
+++ b/src/hooks/api/auth/useSignUp.ts
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 
 import { Profile } from '@/models/auth';
 import { postUserProfile } from '@/services/api/auth';
+import { removeItem } from '@/services/storage';
 
 import useCatchErrorWithToast from '../useCatchErrorWithToast';
 
@@ -15,6 +16,7 @@ function useSignUp() {
     void, FirestoreError, Profile
   >((profile) => postUserProfile(profile), {
     onSuccess: () => {
+      removeItem('isSignUp');
       replace('/');
     },
   });

--- a/src/recoil/group/atom.ts
+++ b/src/recoil/group/atom.ts
@@ -2,12 +2,13 @@ import { atom } from 'recoil';
 
 import { FilterGroupsCondition, initialWriteFieldsState, WriteFields } from '@/models/group';
 import { loadItem } from '@/services/storage';
+import { trueOrFalse } from '@/utils/utils';
 
 export const groupsConditionState = atom<FilterGroupsCondition>({
   key: 'groupsConditionState',
   default: {
     category: ['study', 'project'],
-    isFilterCompleted: loadItem('isFilterCompleted'),
+    isFilterCompleted: trueOrFalse(loadItem<boolean>('isFilterCompleted')),
   },
 });
 

--- a/src/services/__mocks__/storage.ts
+++ b/src/services/__mocks__/storage.ts
@@ -1,0 +1,5 @@
+export const saveItem = jest.fn();
+
+export const loadItem = jest.fn();
+
+export const removeItem = jest.fn();

--- a/src/services/api/__mocks__/auth.ts
+++ b/src/services/api/__mocks__/auth.ts
@@ -5,3 +5,5 @@ export const getUserProfile = jest.fn();
 export const postSignOut = jest.fn();
 
 export const postSignIn = jest.fn();
+
+export const getAuthRedirectResult = jest.fn();

--- a/src/services/api/__mocks__/storage.ts
+++ b/src/services/api/__mocks__/storage.ts
@@ -1,9 +1,0 @@
-const saveItem = jest.fn();
-const loadItem = jest.fn();
-const removeItem = jest.fn();
-
-export {
-  loadItem,
-  removeItem,
-  saveItem,
-};

--- a/src/services/api/auth.test.ts
+++ b/src/services/api/auth.test.ts
@@ -1,11 +1,14 @@
-import { signOut } from 'firebase/auth';
+import { getRedirectResult, signOut } from 'firebase/auth';
 import { getDoc, setDoc } from 'firebase/firestore';
 
-import PROFILE_FIXTURE from '../../../fixtures/profile';
+import FIXTURE_PROFILE from '../../../fixtures/profile';
 import { docRef } from '../firebase';
 
 import {
-  getUserProfile, postSignOut, postUserProfile,
+  getAuthRedirectResult,
+  getUserProfile,
+  postSignOut,
+  postUserProfile,
 } from './auth';
 
 jest.mock('../firebase');
@@ -27,9 +30,9 @@ describe('auth API', () => {
     });
 
     it('updateDoc 함수가 호출되어야만 한다', async () => {
-      await postUserProfile(PROFILE_FIXTURE);
+      await postUserProfile(FIXTURE_PROFILE);
 
-      expect(setDoc).toBeCalledWith(userRef, PROFILE_FIXTURE);
+      expect(setDoc).toBeCalledWith(userRef, FIXTURE_PROFILE);
     });
   });
 
@@ -68,6 +71,21 @@ describe('auth API', () => {
       await postSignOut();
 
       expect(signOut).toBeCalled();
+    });
+  });
+
+  describe('getAuthRedirectResult', () => {
+    beforeEach(() => {
+      (getRedirectResult as jest.Mock).mockImplementation(() => ({
+        user: FIXTURE_PROFILE,
+      }));
+    });
+
+    it('"getRedirectResult"이 호출되어야만 한다', async () => {
+      const user = await getAuthRedirectResult();
+
+      expect(getRedirectResult).toBeCalled();
+      expect(user).toEqual(FIXTURE_PROFILE);
     });
   });
 });

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -1,4 +1,6 @@
-import { signOut, updateProfile, User } from 'firebase/auth';
+import {
+  getRedirectResult, signOut, updateProfile, User,
+} from 'firebase/auth';
 import { getDoc, setDoc } from 'firebase/firestore';
 
 import { Profile } from '@/models/auth';
@@ -32,4 +34,10 @@ export const getUserProfile = async (uid?: string): Promise<Profile | null> => {
 
 export const postSignOut = async () => {
   await signOut(firebaseAuth);
+};
+
+export const getAuthRedirectResult = async (): Promise<User | undefined> => {
+  const user = await getRedirectResult(firebaseAuth);
+
+  return user?.user;
 };

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -64,12 +64,12 @@ describe('storage', () => {
           windowSpy.mockRestore();
         });
 
-        it('false를 반환해야만 한다', () => {
+        it('null를 반환해야만 한다', () => {
           windowSpy.mockImplementation(() => undefined);
 
           const result = loadItem('key');
 
-          expect(result).toBeFalsy();
+          expect(result).toBeNull();
         });
       });
     });
@@ -81,7 +81,7 @@ describe('storage', () => {
         const result = loadItem('key');
 
         expect(spyOnParse).toBeCalled();
-        expect(result).toBeFalsy();
+        expect(result).toBeNull();
       });
     });
   });

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,21 +1,19 @@
-export const CURRENT_USER = 'CURRENT_USER' as const;
-
 export const saveItem = (key: string, value: any) => {
   localStorage.setItem(key, JSON.stringify(value));
 };
 
-export const loadItem = (key: string) => {
+export const loadItem = <T>(key: string) => {
   if (typeof window === 'undefined') {
-    return false;
+    return null;
   }
 
   try {
     const item = localStorage.getItem(key);
     const parsed = JSON.parse(item || '');
 
-    return parsed;
+    return parsed as T | null;
   } catch (error) {
-    return false;
+    return null;
   }
 };
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -13,6 +13,7 @@ import {
   removeToken,
   stringToExcludeNull,
   tomorrow,
+  trueOrFalse,
   yesterday,
 } from './utils';
 
@@ -230,5 +231,23 @@ describe('removeToken', () => {
     removeToken();
 
     expect(setCookie).toBeCalledWith(null, 'token', '', { path: '/' });
+  });
+});
+
+describe('trueOrFalse', () => {
+  context('falsy한 값이면', () => {
+    it('false를 반환해야만 한다', () => {
+      const result = trueOrFalse('');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  context('truthy한 값이면', () => {
+    it('true를 반환해야만 한다', () => {
+      const result = trueOrFalse('test');
+
+      expect(result).toBe(true);
+    });
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -64,3 +64,11 @@ export const removeToken = () => {
   destroyCookie(null, 'token');
   setCookie(null, 'token', '', { path: '/' });
 };
+
+export const trueOrFalse = (value?: string | null | number | boolean): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
- "시작하기"(/signup) 페이지로 redirection
- 만약 시작하기 페이지에서 "확인" 버튼을 눌러 가입하지 않았다면 세션 삭제
- 다만, 해당 렌더링된 브라우저인 경우만 세션이 유지되어 "시작하기" 페이지에 접근가능.
- 나머지 경우 firebase auth 세션 삭제