### PR TITLE
[Feature] 디테일 페이지의 내용에 각 태그별 CSS 및 이모지를 적용하라

### DIFF
--- a/__mocks__/@remirror/react.js
+++ b/__mocks__/@remirror/react.js
@@ -55,3 +55,5 @@ export const useActive = jest.fn().mockImplementation(() => ({
 }));
 
 export const EditorComponent = () => <>mockComponent</>;
+
+export const EmojiPopupComponent = () => <>mockComponent</>;

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "rehype-stringify": "^9.0.3",
     "remirror": "^1.0.67",
     "sanitize-html": "^2.7.0",
+    "svgmoji": "^3.2.0",
     "unified": "^10.1.1",
     "unist-util-visit": "^4.1.0",
     "yup": "^0.32.11"

--- a/src/components/applicants/ApplicantItem.tsx
+++ b/src/components/applicants/ApplicantItem.tsx
@@ -6,6 +6,7 @@ import { Applicant } from '@/models/group';
 import Divider from '@/styles/Divider';
 import { body1Font, body2Font, subtitle1Font } from '@/styles/fontStyles';
 import palette from '@/styles/palette';
+import styledAnchor from '@/styles/styledAnchor';
 import { emptyAThenB, stringToExcludeNull } from '@/utils/utils';
 
 import Button from '../common/Button';
@@ -100,19 +101,10 @@ const ApplicantTextWrapper = styled.div`
 `;
 
 const MetadataWrapper = styled.div`
+  ${styledAnchor}
   display: flex;
   flex-direction: row;
   align-items: center;
-
-  & > a {
-    color: ${palette.success10};
-    transition: color 0.1s ease-in-out;
-
-    &:hover {
-      color: ${palette.success};
-      text-decoration: underline;
-    }
-  }
 `;
 
 const IntroduceBlock = styled.div`

--- a/src/components/detail/DetailContentsSection.tsx
+++ b/src/components/detail/DetailContentsSection.tsx
@@ -1,13 +1,15 @@
 import React, { memo, ReactElement } from 'react';
 
 import styled from '@emotion/styled';
+import { extensionEmojiStyledCss } from '@remirror/styles/emotion';
 import rehypeParse from 'rehype-parse';
 import rehypeStringify from 'rehype-stringify';
 import { unified } from 'unified';
 
 import { Group } from '@/models/group';
-import { body2Font } from '@/styles/fontStyles';
+import { body1Font, body2Font } from '@/styles/fontStyles';
 import palette from '@/styles/palette';
+import styledAnchor from '@/styles/styledAnchor';
 import { filteredWithSanitizeHtml } from '@/utils/filter';
 import rehypePrism from '@/utils/rehypePrism';
 
@@ -76,7 +78,37 @@ const TagsWrapper = styled.div`
 `;
 
 const DetailContentWrapper = styled.div`
+  ${extensionEmojiStyledCss}
   margin-bottom: 36px;
+
+  p {
+    ${body1Font()}
+    ${styledAnchor}
+    margin: 0;
+
+    & > code {
+      padding: 0.2em 0.4em;
+      margin: 0;
+      font-size: 85%;
+      background-color: ${palette.accent2};
+      border-radius: 6px;
+    }
+  }
+
+  hr {
+    border: .5px solid ${palette.accent4}
+  }
+
+  blockquote {
+    border-left: 4px solid ${palette.accent3};
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 15px;
+
+    & p {
+      color: ${palette.accent5}
+    }
+  }
 `;
 
 const DetailContentsWrapper = styled.div`

--- a/src/components/write/RemirorEditorProvider.tsx
+++ b/src/components/write/RemirorEditorProvider.tsx
@@ -16,6 +16,7 @@ import {
   CodeBlockExtension,
   CodeExtension,
   DropCursorExtension,
+  EmojiExtension,
   HeadingExtension,
   HorizontalRuleExtension,
   ImageExtension,
@@ -26,6 +27,7 @@ import {
   UnderlineExtension,
   WhitespaceExtension,
 } from 'remirror/extensions';
+import emojiData from 'svgmoji/emoji.json';
 
 import palette from '@/styles/palette';
 
@@ -48,6 +50,7 @@ const extensions = () => [
     supportedLanguages: [css, javascript, json, markdown, typescript, java],
     syntaxTheme: 'dracula',
   }),
+  new EmojiExtension({ data: emojiData, moji: 'twemoji' }),
   new HorizontalRuleExtension(),
   new CodeExtension(),
   new UnderlineExtension(),

--- a/src/components/write/WriteEditor.test.tsx
+++ b/src/components/write/WriteEditor.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+
+import WriteEditor from './WriteEditor';
+
+jest.mock('@remirror/react');
+
+describe('WriteEditor', () => {
+  const handleChange = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+  });
+
+  const renderWriteEditor = () => render((
+    <WriteEditor />
+  ));
+
+  it('에디터에 대한 내용이 보여야만 한다', () => {
+    renderWriteEditor();
+
+    expect(screen.getByTestId('h1-button')).toBeInTheDocument();
+  });
+});

--- a/src/components/write/WriteEditor.tsx
+++ b/src/components/write/WriteEditor.tsx
@@ -1,8 +1,17 @@
 import React, { ReactElement } from 'react';
 
 import styled from '@emotion/styled';
-import { EditorComponent } from '@remirror/react';
-import { AllStyledComponent } from '@remirror/styles/emotion';
+import { EditorComponent, EmojiPopupComponent } from '@remirror/react';
+import {
+  CoreStyledComponent,
+  extensionEmojiStyledCss,
+  extensionGapCursorStyledCss,
+  extensionImageStyledCss,
+  extensionListStyledCss,
+  extensionPlaceholderStyledCss,
+  extensionPositionerStyledCss,
+  extensionWhitespaceStyledCss,
+} from '@remirror/styles/emotion';
 
 import EditorToolbar from '@/components/write/EditorToolbar';
 import { body1Font } from '@/styles/fontStyles';
@@ -13,6 +22,7 @@ function WriteEditor(): ReactElement {
     <>
       <EditorToolbar />
       <RemirrorEditorWrapper>
+        <EmojiPopupComponent />
         <EditorComponent />
       </RemirrorEditorWrapper>
     </>
@@ -21,7 +31,14 @@ function WriteEditor(): ReactElement {
 
 export default WriteEditor;
 
-const RemirrorEditorWrapper = styled(AllStyledComponent)`
+const RemirrorEditorWrapper = styled(CoreStyledComponent)`
+  ${extensionListStyledCss}
+  ${extensionGapCursorStyledCss}
+  ${extensionImageStyledCss}
+  ${extensionPlaceholderStyledCss}
+  ${extensionEmojiStyledCss}
+  ${extensionWhitespaceStyledCss}
+  ${extensionPositionerStyledCss}
   border-bottom: 1px solid ${palette.accent2};
   margin-bottom: 24px;
 
@@ -50,9 +67,14 @@ const RemirrorEditorWrapper = styled(AllStyledComponent)`
   }
 
   .ProseMirror blockquote {
-    border-left: 4px solid ${palette.accent3} !important;
-    font-style: normal !important;
-    padding-left: 15px !important;
+    border-left: 4px solid ${palette.accent3};
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 15px;
+
+    & p {
+      color: ${palette.accent5}
+    }
   }
 
   .ProseMirror ::selection {
@@ -67,6 +89,10 @@ const RemirrorEditorWrapper = styled(AllStyledComponent)`
     ${body1Font()}
     font-style: normal;
     color: ${palette.accent4};
+  }
+
+  .remirror-emoji-popup-highlight {
+    background-color: ${palette.accent1};
   }
 
   & >.remirror-editor-wrapper {

--- a/src/styles/StyledToastContainer.ts
+++ b/src/styles/StyledToastContainer.ts
@@ -6,29 +6,29 @@ import { body2Font } from './fontStyles';
 import palette from './palette';
 
 const StyledToastContainer = styled(ToastContainer)`
-width: 328px;
+  width: 328px;
 
-.Toastify__toast {
-  ${body2Font()}
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
-  color: ${palette.accent7};
-  border-radius: 8px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 15px 16px;
-  border-radius: 8px;
-  min-height: 56px;
-}
+  .Toastify__toast {
+    ${body2Font()}
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
+    color: ${palette.accent7};
+    border-radius: 8px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 15px 16px;
+    border-radius: 8px;
+    min-height: 56px;
+  }
 
-.Toastify__toast-body {
-  padding: 0px;
-  margin: 0 10px 0 0;
-}
+  .Toastify__toast-body {
+    padding: 0px;
+    margin: 0 10px 0 0;
+  }
 
-.Toastify__toast-icon {
-  width: auto;
-}
+  .Toastify__toast-icon {
+    width: auto;
+  }
 `;
 
 export default StyledToastContainer;

--- a/src/styles/styledAnchor.ts
+++ b/src/styles/styledAnchor.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+
+import palette from './palette';
+
+const styledAnchor = css`
+  a {
+    color: ${palette.success10};
+    transition: color 0.1s ease-in-out;
+  
+    &:hover {
+      color: ${palette.success};
+      text-decoration: underline;
+    }
+  }
+`;
+
+export default styledAnchor;


### PR DESCRIPTION
- 디테일 페이지의 내용에 각 태그별 CSS 적용 및 이모지 적용
- editor에 twemoji 이모지 추가
- Install svgmoji dependency

<img width="793" alt="image" src="https://user-images.githubusercontent.com/60910665/156909034-3ae81bab-ce0b-4aa0-ae13-d608db5d2da4.png">
