### PR TITLE
[Improve] 팀 신청 알람 메시지 클릭시 신청 취소한 사용자인 경우 에러 케이스를 추가하라

### DIFF
--- a/src/components/alarm/AlarmItem.tsx
+++ b/src/components/alarm/AlarmItem.tsx
@@ -45,7 +45,7 @@ function AlarmItem({ alarm }: Props): ReactElement {
     applied: `${applicant?.name}님이 팀원을 신청했어요.`,
   };
 
-  const alarmUrl = type === 'applied' ? `/detail/${group.groupId}/applicants` : `/detail/${group.groupId}`;
+  const alarmUrl = type === 'applied' ? `/detail/${group.groupId}/applicants?applicant=${applicant?.uid}` : `/detail/${group.groupId}`;
 
   return (
     <Link href={alarmUrl} passHref>

--- a/src/containers/applicants/ApplicationStatusContainer.test.tsx
+++ b/src/containers/applicants/ApplicationStatusContainer.test.tsx
@@ -1,30 +1,40 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { useRouter } from 'next/router';
 
 import useFetchApplicants from '@/hooks/api/applicant/useFetchApplicants';
 import useUpdateApplicant from '@/hooks/api/applicant/useUpdateApplicant';
+import { errorToast } from '@/utils/toast';
 
 import APPLICANT_FIXTURE from '../../../fixtures/applicant';
 
 import ApplicationStatusContainer from './ApplicationStatusContainer';
 
+jest.mock('@/utils/toast');
 jest.mock('@/hooks/api/applicant/useFetchApplicants');
 jest.mock('@/hooks/api/applicant/useUpdateApplicant');
 jest.mock('next/router', () => ({
-  useRouter: jest.fn().mockImplementation(() => ({
-    back: jest.fn(),
-  })),
+  useRouter: jest.fn(),
 }));
 
 describe('ApplicationStatusContainer', () => {
   const mutate = jest.fn();
 
   beforeEach(() => {
-    mutate.mockClear();
+    jest.clearAllMocks();
+
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      back: jest.fn(),
+      query: {
+        applicant: given.query,
+      },
+    }));
 
     (useFetchApplicants as jest.Mock).mockImplementation(() => ({
-      data: [APPLICANT_FIXTURE],
+      data: given.applicants || [],
       isLoading: given.isLoading,
+      isSuccess: true,
     }));
+
     (useUpdateApplicant as jest.Mock).mockImplementation(() => ({
       mutate,
     }));
@@ -46,6 +56,7 @@ describe('ApplicationStatusContainer', () => {
 
   context('로딩중이 아닌 경우', () => {
     given('isLoading', () => false);
+    given('applicants', () => [APPLICANT_FIXTURE]);
 
     describe('"선택" 버튼을 클릭한다', () => {
       it('toggleConfirm mutate 액션이 호출되어야만 한다', () => {
@@ -57,6 +68,30 @@ describe('ApplicationStatusContainer', () => {
           ...APPLICANT_FIXTURE,
           isConfirm: !APPLICANT_FIXTURE.isConfirm,
         });
+      });
+    });
+
+    context('API가 로딩중이 아니고 성공하고 query의 applicant가 신청자리스트에 존재하지 않는 경우', () => {
+      given('isLoading', () => false);
+      given('applicants', () => [APPLICANT_FIXTURE]);
+      given('query', () => 'applicantId');
+
+      it('errorToast가 "신청을 취소한 사용자에요."와 함께 호출되어야만 한다', () => {
+        renderApplicationStatusContainer();
+
+        expect(errorToast).toBeCalledWith('신청을 취소한 사용자에요.');
+      });
+    });
+
+    context('API가 로딩중이 아니고 성공하고 query의 applicant가 신청자리스트에 존재하는 경우', () => {
+      given('isLoading', () => false);
+      given('applicants', () => [APPLICANT_FIXTURE]);
+      given('query', () => '12345678');
+
+      it('errorToast가 호출되지 않아야만 한다', () => {
+        renderApplicationStatusContainer();
+
+        expect(errorToast).not.toBeCalled();
       });
     });
   });

--- a/src/containers/applicants/ApplicationStatusContainer.tsx
+++ b/src/containers/applicants/ApplicationStatusContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback, useEffect } from 'react';
 
 import { useRouter } from 'next/router';
 
@@ -7,16 +7,29 @@ import useFetchApplicants from '@/hooks/api/applicant/useFetchApplicants';
 import useUpdateApplicant from '@/hooks/api/applicant/useUpdateApplicant';
 import { Applicant } from '@/models/group';
 import { DetailLayout } from '@/styles/Layout';
+import { errorToast } from '@/utils/toast';
 
 function ApplicationStatusContainer(): ReactElement {
-  const { back } = useRouter();
-  const { data: applicants, isLoading } = useFetchApplicants();
+  const { query, back } = useRouter();
+  const { data: applicants, isLoading, isSuccess } = useFetchApplicants();
   const { mutate } = useUpdateApplicant();
 
   const onToggleConfirm = useCallback((applicant: Applicant) => mutate({
     ...applicant,
     isConfirm: !applicant.isConfirm,
   }), [mutate]);
+
+  useEffect(() => {
+    if (!query?.applicant || isLoading || !isSuccess) {
+      return;
+    }
+
+    const isApplicant = applicants.some(({ applicant }) => applicant.uid === query.applicant);
+
+    if (!isApplicant) {
+      errorToast('신청을 취소한 사용자에요.');
+    }
+  }, [query, applicants, isLoading, isSuccess]);
 
   if (isLoading) {
     return <DetailLayout>로딩중...</DetailLayout>;


### PR DESCRIPTION
- 내 알람의 팀 신청 알람 메시지 클릭시 신청자 페이지로 이동 => 신청 취소한 사용자인 경우 => toast 에러 메시지가 나타난다.
- Error Message: "신청을 취소한 사용자에요."