### PR TITLE
fix: 댓글이 새로고침을 하지 않으면 반영이 안되는 이슈를 수정하라

### DIFF
--- a/__mocks__/firebase/auth.js
+++ b/__mocks__/firebase/auth.js
@@ -19,3 +19,10 @@ export const setPersistence = jest.fn();
 export const onIdTokenChanged = jest.fn();
 
 export const deleteUser = jest.fn();
+
+export const AuthErrorCodes = {
+  CREDENTIAL_TOO_OLD_LOGIN_AGAIN: 'auth/requires-recent-login',
+  TIMEOUT: 'auth/timeout',
+  TOO_MANY_ATTEMPTS_TRY_LATER: 'auth/too-many-requests',
+  TOKEN_EXPIRED: 'auth/user-token-expired',
+};

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-toastify": "^8.2.0",
     "react-toggle": "^4.1.2",
     "react-use": "^17.4.0",
-    "recoil": "^0.7.2",
+    "recoil": "^0.7.4",
     "refractor": "^4.7.0",
     "rehype-parse": "^8.0.4",
     "rehype-stringify": "^9.0.3",

--- a/src/hooks/api/auth/useAccountWithdrawal.ts
+++ b/src/hooks/api/auth/useAccountWithdrawal.ts
@@ -8,6 +8,8 @@ import { deleteMember } from '@/services/api/auth';
 import { successToast } from '@/utils/toast';
 import { removeToken } from '@/utils/utils';
 
+import useCatchAuthErrorWithToast from '../useCatchAuthErrorWithToast';
+
 function useAccountWithdrawal() {
   const { replace } = useRouter();
   const queryClient = useQueryClient();
@@ -22,6 +24,14 @@ function useAccountWithdrawal() {
       replace('/', undefined, { shallow: true });
       successToast('회원탈퇴를 완료했어요.');
     },
+  });
+
+  const { isError, error } = mutation;
+
+  useCatchAuthErrorWithToast({
+    isError,
+    error,
+    defaultErrorMessage: '회원탈퇴에 실패했어요!',
   });
 
   return mutation;

--- a/src/hooks/api/auth/useSignOut.ts
+++ b/src/hooks/api/auth/useSignOut.ts
@@ -7,6 +7,8 @@ import { Profile } from '@/models/auth';
 import { postSignOut } from '@/services/api/auth';
 import { removeToken } from '@/utils/utils';
 
+import useCatchAuthErrorWithToast from '../useCatchAuthErrorWithToast';
+
 function useSignOut() {
   const { replace } = useRouter();
   const queryClient = useQueryClient();
@@ -20,6 +22,14 @@ function useSignOut() {
       queryClient.setQueryData<User | null>(['authRedirectResult'], () => null);
       replace('/', undefined, { shallow: true });
     },
+  });
+
+  const { isError, error } = mutation;
+
+  useCatchAuthErrorWithToast({
+    isError,
+    error,
+    defaultErrorMessage: '회원탈퇴에 실패했어요!',
   });
 
   return mutation;

--- a/src/hooks/api/comment/useAddComment.ts
+++ b/src/hooks/api/comment/useAddComment.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from 'react-query';
 
 import { FirestoreError } from 'firebase/firestore';
 
-import { Comment, CommentForm } from '@/models/group';
+import { CommentForm } from '@/models/group';
 import { postGroupComment } from '@/services/api/comment';
 
 import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast';
@@ -13,15 +13,10 @@ function useAddComment() {
   const mutation = useMutation<string, FirestoreError, CommentForm>((
     commentForm,
   ) => postGroupComment(commentForm), {
-    onSuccess: (commentId: string, commentForm: CommentForm) => {
-      queryClient.setQueryData<Comment[]>(['comments', commentForm.groupId], (comments = []) => [
-        ...comments,
-        {
-          ...commentForm,
-          commentId,
-          createdAt: new Date().toString(),
-        },
-      ]);
+    onSuccess: (_, commentForm: CommentForm) => {
+      queryClient.invalidateQueries(['comments', {
+        id: commentForm.groupId,
+      }]);
     },
   });
 

--- a/src/hooks/api/comment/useDeleteComment.test.ts
+++ b/src/hooks/api/comment/useDeleteComment.test.ts
@@ -3,9 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { deleteGroupComment } from '@/services/api/comment';
 import wrapper from '@/test/ReactQueryWrapper';
 
-import FIXTURE_COMMENT from '../../../../fixtures/comment';
-
-import useDeleteComment, { filteredRemoveComment } from './useDeleteComment';
+import useDeleteComment from './useDeleteComment';
 
 jest.mock('@/services/api/comment');
 jest.mock('@/hooks/useRenderSuccessToast');
@@ -30,15 +28,5 @@ describe('useDeleteComment', () => {
     });
 
     expect(result.current.isSuccess).toBeTruthy();
-  });
-});
-
-describe('filteredRemoveComment', () => {
-  const comments = [FIXTURE_COMMENT];
-
-  it('commentId와 다른 comment만 반환해야만 한다', () => {
-    const result = filteredRemoveComment('2')(comments);
-
-    expect(result).toEqual(comments);
   });
 });

--- a/src/hooks/api/comment/useDeleteComment.ts
+++ b/src/hooks/api/comment/useDeleteComment.ts
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from 'react-query';
 import { FirestoreError } from 'firebase/firestore';
 
 import useRenderSuccessToast from '@/hooks/useRenderSuccessToast';
-import { Comment } from '@/models/group';
 import { deleteGroupComment } from '@/services/api/comment';
 
 import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast';
@@ -19,8 +18,10 @@ function useDeleteComment() {
   const mutation = useMutation<void, FirestoreError, DeleteCommentForm>((
     commentForm,
   ) => deleteGroupComment(commentForm.commentId), {
-    onSuccess: (_: void, { groupId, commentId }: DeleteCommentForm) => {
-      queryClient.setQueryData<Comment[]>(['comments', groupId], filteredRemoveComment(commentId));
+    onSuccess: (_: void, { groupId }: DeleteCommentForm) => {
+      queryClient.invalidateQueries(['comments', {
+        id: groupId,
+      }]);
     },
   });
 
@@ -38,7 +39,3 @@ function useDeleteComment() {
 }
 
 export default useDeleteComment;
-
-export const filteredRemoveComment = (removeId: string) => (
-  comments: Comment[] = [],
-) => comments.filter(({ commentId }) => commentId !== removeId);

--- a/src/hooks/api/useCatchAuthErrorWithToast.test.ts
+++ b/src/hooks/api/useCatchAuthErrorWithToast.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+
+import { errorToast } from '@/utils/toast';
+
+import useCatchAuthErrorWithToast from './useCatchAuthErrorWithToast';
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+jest.mock('@/utils/toast');
+
+describe('useCatchAuthErrorWithToast', () => {
+  const defaultErrorMessage = 'defaultErrorMessage';
+
+  const useCatchAuthErrorWithToastHook = () => renderHook(
+    () => useCatchAuthErrorWithToast({
+      error: given.error,
+      isError: given.isError,
+      defaultErrorMessage,
+    }),
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  context('isError가 false이고 error가 존재하지 않을 경우', () => {
+    given('isError', () => false);
+    given('error', () => null);
+
+    it('errorToast는 호출되지 않아야만 한다', () => {
+      useCatchAuthErrorWithToastHook();
+
+      expect(errorToast).not.toBeCalled();
+    });
+  });
+
+  context('isError가 true이고 error가 존재하지 않을 경우', () => {
+    given('isError', () => true);
+    given('error', () => null);
+
+    it('errorToast는 기본 에러 메시지와 함께 호출되어야만 한다', () => {
+      useCatchAuthErrorWithToastHook();
+
+      expect(errorToast).toBeCalledWith(defaultErrorMessage);
+    });
+  });
+
+  context('isError가 true이고 error가 존재하는 경우', () => {
+    given('isError', () => true);
+
+    context('error의 code가 존재하지 않는 경우', () => {
+      given('error', () => ('error'));
+
+      it('errorToast는 "알 수 없는 오류가 발생했습니다."와 함께 호출되어야만 한다', () => {
+        useCatchAuthErrorWithToastHook();
+
+        expect(errorToast).toBeCalledWith('알 수 없는 오류가 발생했습니다.');
+      });
+    });
+
+    context('error의 code가 존재하는 경우', () => {
+      given('error', () => ({
+        code: 'auth/requires-recent-login',
+      }));
+
+      it('errorToast는 code의 error 메시지와 함께 호출되어야만 한다', () => {
+        useCatchAuthErrorWithToastHook();
+
+        expect(errorToast).toBeCalledWith('다시 로그인 후 진행해주세요.');
+      });
+    });
+  });
+});

--- a/src/hooks/api/useCatchAuthErrorWithToast.ts
+++ b/src/hooks/api/useCatchAuthErrorWithToast.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+
+import { AuthError, AuthErrorCodes } from 'firebase/auth';
+
+import { errorToast } from '@/utils/toast';
+
+interface Props {
+  isError: boolean;
+  error: AuthError | null;
+  defaultErrorMessage: string;
+}
+
+function useCatchAuthErrorWithToast({ isError, error, defaultErrorMessage }: Props) {
+  useEffect(() => {
+    const {
+      CREDENTIAL_TOO_OLD_LOGIN_AGAIN, TIMEOUT, TOO_MANY_ATTEMPTS_TRY_LATER, TOKEN_EXPIRED,
+    } = AuthErrorCodes;
+
+    const authErrorMessage = {
+      [CREDENTIAL_TOO_OLD_LOGIN_AGAIN]: '다시 로그인 후 진행해주세요.',
+      [TIMEOUT]: '잠시 후 다시 시도해주세요.',
+      [TOO_MANY_ATTEMPTS_TRY_LATER]: '잠시 후 다시 시도해주세요.',
+      [TOKEN_EXPIRED]: '토큰이 만료되었어요. 다시 로그인 후 진행해주세요.',
+      unknown: '알 수 없는 오류가 발생했습니다.',
+    } as any;
+
+    if (!isError && !error) {
+      return;
+    }
+
+    if (isError && !error) {
+      errorToast(defaultErrorMessage);
+      return;
+    }
+
+    errorToast(authErrorMessage[error?.code || 'unknown']);
+  }, [isError, error, defaultErrorMessage]);
+}
+
+export default useCatchAuthErrorWithToast;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15505,10 +15505,10 @@ reakit@^1.3.11:
     reakit-utils "^0.15.2"
     reakit-warning "^0.6.2"
 
-recoil@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.2.tgz#37aafc9e0674abae639263354a11c910e71bf78a"
-  integrity sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g==
+recoil@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.4.tgz#d6508fa656d9c93e66fdf334e1f723a9e98801cf"
+  integrity sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==
   dependencies:
     hamt_plus "1.0.2"
 


### PR DESCRIPTION
- 무한스크롤적용하면서 react-query key값이 변경되었는데 작성 및 삭제시 react-query key값이 일치하지 않아서 업데이트가 되지 않았음.
- 키 값을 일치시켜 invalidate query를 적용한다.
- 인증 관련 부분 api 실패시 error toast 적용