### PR TITLE
fix: 회원탈퇴가 정상적으로 동작하지 않는 이슈를 수정하라

### DIFF
--- a/__mocks__/firebase/auth.js
+++ b/__mocks__/firebase/auth.js
@@ -20,6 +20,8 @@ export const onIdTokenChanged = jest.fn();
 
 export const deleteUser = jest.fn();
 
+export const reauthenticateWithRedirect = jest.fn();
+
 export const AuthErrorCodes = {
   CREDENTIAL_TOO_OLD_LOGIN_AGAIN: 'auth/requires-recent-login',
   TIMEOUT: 'auth/timeout',

--- a/src/containers/myInfo/MyInfoSettingContainer.test.tsx
+++ b/src/containers/myInfo/MyInfoSettingContainer.test.tsx
@@ -1,8 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  fireEvent, render, screen,
+} from '@testing-library/react';
+import { act } from '@testing-library/react-hooks';
 import { useRouter } from 'next/router';
 
 import useAccountWithdrawal from '@/hooks/api/auth/useAccountWithdrawal';
+import useAuthRedirectResult from '@/hooks/api/auth/useAuthRedirectResult';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
+import useReauthenticateWithProvider from '@/hooks/api/auth/useReauthenticateWithProvider';
+import ReactQueryWrapper from '@/test/ReactQueryWrapper';
 
 import FIXTURE_PROFILE from '../../../fixtures/profile';
 
@@ -10,13 +16,15 @@ import MyInfoSettingContainer from './MyInfoSettingContainer';
 
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
 jest.mock('@/hooks/api/auth/useAccountWithdrawal');
+jest.mock('@/hooks/api/auth/useAuthRedirectResult');
+jest.mock('@/hooks/api/auth/useReauthenticateWithProvider');
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }));
 
 describe('MyInfoSettingContainer', () => {
   const mockReplace = jest.fn();
-  const deleteMemberMutate = jest.fn();
+  const mutate = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -25,14 +33,23 @@ describe('MyInfoSettingContainer', () => {
       replace: mockReplace,
     }));
 
+    (useAuthRedirectResult as jest.Mock).mockImplementation(() => ({
+      data: FIXTURE_PROFILE,
+    }));
+
+    (useReauthenticateWithProvider as jest.Mock).mockImplementation(() => ({
+      mutate,
+    }));
     (useFetchUserProfile as jest.Mock).mockImplementation(() => (given.profileStatus));
     (useAccountWithdrawal as jest.Mock).mockImplementation(() => ({
-      mutate: deleteMemberMutate,
+      mutate,
     }));
   });
 
   const renderMyInfoSettingContainer = () => render((
-    <MyInfoSettingContainer />
+    <ReactQueryWrapper>
+      <MyInfoSettingContainer />
+    </ReactQueryWrapper>
   ));
 
   context('로딩중인 경우', () => {
@@ -42,10 +59,10 @@ describe('MyInfoSettingContainer', () => {
       isSuccess: false,
     }));
 
-    it('"로딩중..."문구가 나타나야만 한다', () => {
+    it('"로딩중..."문구가 나타나야만 한다', async () => {
       const { container } = renderMyInfoSettingContainer();
 
-      expect(container).toHaveTextContent('로딩중...');
+      await act(() => expect(container).toHaveTextContent('로딩중...'));
     });
   });
 
@@ -70,20 +87,20 @@ describe('MyInfoSettingContainer', () => {
       isSuccess: true,
     }));
 
-    it('내 정보 수정 페이지에 대한 내용이 나타나야만 한다', () => {
+    it('내 정보 수정 페이지에 대한 내용이 나타나야만 한다', async () => {
       const { container } = renderMyInfoSettingContainer();
 
-      expect(container).toHaveTextContent(`${FIXTURE_PROFILE.position}`);
+      await act(() => expect(container).toHaveTextContent(`${FIXTURE_PROFILE.position}`));
     });
 
     describe('회원 탈퇴 모달창에서 "탈퇴하기" 버튼을 클릭한다', () => {
-      it('클릭 이벤트가 호출되어야만 한다', () => {
+      it('클릭 이벤트가 호출되어야만 한다', async () => {
         renderMyInfoSettingContainer();
 
         fireEvent.click(screen.getByText('회원 탈퇴하기'));
         fireEvent.click(screen.getByText('탈퇴하기'));
 
-        expect(deleteMemberMutate).toBeCalled();
+        expect(mutate).toBeCalledTimes(2);
       });
     });
   });

--- a/src/hooks/api/auth/useAccountWithdrawal.test.ts
+++ b/src/hooks/api/auth/useAccountWithdrawal.test.ts
@@ -36,6 +36,6 @@ describe('useAccountWithdrawal', () => {
 
     expect(deleteMember).toBeCalled();
     expect(result.current.isSuccess).toBeTruthy();
-    expect(replace).toBeCalledWith('/', undefined, { shallow: true });
+    expect(replace).toBeCalledWith('/');
   });
 });

--- a/src/hooks/api/auth/useAccountWithdrawal.ts
+++ b/src/hooks/api/auth/useAccountWithdrawal.ts
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 
 import { Profile } from '@/models/auth';
 import { deleteMember } from '@/services/api/auth';
+import { removeItem } from '@/services/storage';
 import { successToast } from '@/utils/toast';
 import { removeToken } from '@/utils/utils';
 
@@ -21,7 +22,8 @@ function useAccountWithdrawal() {
       queryClient.setQueryData<IdTokenResult | null>(['token'], () => null);
       queryClient.setQueryData<Profile | null>(['profile'], () => null);
       queryClient.setQueryData<User | null>(['authRedirectResult'], () => null);
-      replace('/', undefined, { shallow: true });
+      removeItem('isReauthenticate');
+      replace('/');
       successToast('회원탈퇴를 완료했어요.');
     },
   });

--- a/src/hooks/api/auth/useReauthenticateWithProvider.test.ts
+++ b/src/hooks/api/auth/useReauthenticateWithProvider.test.ts
@@ -1,0 +1,24 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { postReauthenticateWithProvider } from '@/services/api/auth';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import useReauthenticateWithProvider from './useReauthenticateWithProvider';
+
+jest.mock('@/services/api/auth');
+
+describe('useReauthenticateWithProvider', () => {
+  const useReauthenticateWithProviderHook = () => renderHook(useReauthenticateWithProvider, {
+    wrapper,
+  });
+
+  it('postReauthenticateWithProvider가 호출되어야만 한다', async () => {
+    const { result } = useReauthenticateWithProviderHook();
+
+    await act(async () => {
+      await result.current.mutate();
+    });
+
+    expect(postReauthenticateWithProvider).toBeCalledTimes(1);
+  });
+});

--- a/src/hooks/api/auth/useReauthenticateWithProvider.ts
+++ b/src/hooks/api/auth/useReauthenticateWithProvider.ts
@@ -1,0 +1,23 @@
+import { useMutation } from 'react-query';
+
+import { AuthError } from 'firebase/auth';
+
+import { postReauthenticateWithProvider } from '@/services/api/auth';
+
+import useCatchAuthErrorWithToast from '../useCatchAuthErrorWithToast';
+
+function useReauthenticateWithProvider() {
+  const mutation = useMutation<void, AuthError, void>(postReauthenticateWithProvider);
+
+  const { isError, error } = mutation;
+
+  useCatchAuthErrorWithToast({
+    isError,
+    error,
+    defaultErrorMessage: '회원탈퇴에 실패했어요!',
+  });
+
+  return mutation;
+}
+
+export default useReauthenticateWithProvider;

--- a/src/pages/myinfo/setting.test.tsx
+++ b/src/pages/myinfo/setting.test.tsx
@@ -1,11 +1,13 @@
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
+import useAuthRedirectResult from '@/hooks/api/auth/useAuthRedirectResult';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import ReactQueryWrapper from '@/test/ReactQueryWrapper';
 
 import SettingPage from './setting.page';
 
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
+jest.mock('@/hooks/api/auth/useAuthRedirectResult');
 jest.mock('next/router', () => ({
   useRouter: jest.fn().mockImplementation(() => ({
     replace: jest.fn(),
@@ -19,6 +21,10 @@ describe('SettingPage', () => {
       isLoading: false,
       isSuccess: true,
     }));
+
+    (useAuthRedirectResult as jest.Mock).mockImplementation(() => ({
+      data: null,
+    }));
   });
 
   const renderSettingPage = () => render((
@@ -27,9 +33,9 @@ describe('SettingPage', () => {
     </ReactQueryWrapper>
   ));
 
-  it('내 정보 수정 페이지에 대한 내용이 보여야만 한다', () => {
+  it('내 정보 수정 페이지에 대한 내용이 보여야만 한다', async () => {
     const { container } = renderSettingPage();
 
-    expect(container).toHaveTextContent('저장하기');
+    await act(() => expect(container).toHaveTextContent('저장하기'));
   });
 });

--- a/src/services/api/__mocks__/auth.ts
+++ b/src/services/api/__mocks__/auth.ts
@@ -9,3 +9,5 @@ export const postSignIn = jest.fn();
 export const getAuthRedirectResult = jest.fn();
 
 export const deleteMember = jest.fn();
+
+export const postReauthenticateWithProvider = jest.fn();

--- a/src/services/api/auth.test.ts
+++ b/src/services/api/auth.test.ts
@@ -1,4 +1,6 @@
-import { deleteUser, getRedirectResult, signOut } from 'firebase/auth';
+import {
+  deleteUser, getRedirectResult, reauthenticateWithRedirect, signOut,
+} from 'firebase/auth';
 import { getDoc, setDoc } from 'firebase/firestore';
 
 import FIXTURE_PROFILE from '../../../fixtures/profile';
@@ -8,6 +10,7 @@ import {
   deleteMember,
   getAuthRedirectResult,
   getUserProfile,
+  postReauthenticateWithProvider,
   postSignOut,
   postUserProfile,
 } from './auth';
@@ -87,6 +90,54 @@ describe('auth API', () => {
 
       expect(getRedirectResult).toBeCalled();
       expect(user).toEqual(FIXTURE_PROFILE);
+    });
+  });
+
+  describe('postReauthenticateWithProvider', () => {
+    context('user가 존재하지 않는 경우', () => {
+      beforeEach(() => {
+        (firebaseAuth.currentUser as any) = '';
+      });
+
+      it('"reauthenticateWithRedirect"이 호출되지 않아야만 한다', async () => {
+        await postReauthenticateWithProvider();
+
+        expect(reauthenticateWithRedirect).not.toBeCalled();
+      });
+    });
+
+    context('user가 존재하는 경우', () => {
+      context('providerId가 "google.com"인 경우', () => {
+        beforeEach(() => {
+          (firebaseAuth.currentUser as any) = {
+            providerData: [{
+              providerId: 'google.com',
+            }],
+          };
+        });
+
+        it('"reauthenticateWithRedirect"이 호출되어야만 한다', async () => {
+          await postReauthenticateWithProvider();
+
+          expect(reauthenticateWithRedirect).toBeCalledTimes(1);
+        });
+      });
+
+      context('providerId가 "github.com"인 경우', () => {
+        beforeEach(() => {
+          (firebaseAuth.currentUser as any) = {
+            providerData: [{
+              providerId: 'github.com',
+            }],
+          };
+        });
+
+        it('"reauthenticateWithRedirect"이 호출되어야만 한다', async () => {
+          await postReauthenticateWithProvider();
+
+          expect(reauthenticateWithRedirect).toBeCalledTimes(1);
+        });
+      });
     });
   });
 

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -1,12 +1,13 @@
 import {
-  deleteUser,
-  getRedirectResult, signOut, updateProfile, User,
+  deleteUser, getRedirectResult, reauthenticateWithRedirect, signOut, updateProfile, User,
 } from 'firebase/auth';
 import { getDoc, setDoc } from 'firebase/firestore';
 
 import { Profile } from '@/models/auth';
 
-import { docRef, firebaseAuth } from '../firebase';
+import {
+  docRef, firebaseAuth, githubProvider, googleProvider,
+} from '../firebase';
 
 export const postUserProfile = async (profile: Profile) => {
   const { uid, name, image } = profile;
@@ -41,6 +42,24 @@ export const getAuthRedirectResult = async (): Promise<User | undefined> => {
   const user = await getRedirectResult(firebaseAuth);
 
   return user?.user;
+};
+
+export const postReauthenticateWithProvider = async () => {
+  if (!firebaseAuth.currentUser) {
+    return;
+  }
+
+  const { currentUser: user } = firebaseAuth;
+
+  if (user.providerData?.[0].providerId === 'google.com') {
+    await reauthenticateWithRedirect(user, googleProvider);
+
+    return;
+  }
+
+  if (user.providerData?.[0].providerId === 'github.com') {
+    await reauthenticateWithRedirect(user, githubProvider);
+  }
 };
 
 export const deleteMember = async () => {


### PR DESCRIPTION
- 회원탈퇴가 정상적으로 동작하지 않는 이슈 수정
- firebase 회원 탈퇴시 사용자 재인증이 필요하여 탈퇴가 정상적으로 되지 않는 이슈에 재인증 로직을 추가